### PR TITLE
Added custom url transformation support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,12 +2,11 @@ name: Test
 on:
   push:
     branches:
-      - development
+      - master
 
   pull_request:
     branches:
       - master
-      - development
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -2,13 +2,25 @@
 
 Sitemap generator for next.js. Generate sitemap(s) and robots.txt for all static/pre-rendered pages.
 
-## Installation
+## Table of contents
+
+- Getting started
+  - [Installation](#installation)
+  - [Create config file](#create-config-file)
+  - [Building sitemaps](#building-sitemaps)
+- [Splitting large sitemap into multiple files](#splitting-large-sitemap-into-multiple-files)
+- [Configuration Options](#next-sitemapjs-options)
+- [Full configuration example](#full-configuration-example)
+
+## Getting started
+
+### Installation
 
 ```shell
 yarn add next-sitemap -D
 ```
 
-## Create config file
+### Create config file
 
 `next-sitemap` requires a basic config file (`next-sitemap.js`) under your project root
 
@@ -20,7 +32,9 @@ module.exports = {
 }
 ```
 
-## Add next-sitemap as your postbuild script
+### Building sitemaps
+
+Add next-sitemap as your postbuild script
 
 ```json
 {
@@ -43,7 +57,7 @@ module.exports = {
 
 Above is the minimal configuration to split a large sitemap. When the number of URLs in a sitemap is more than 7000, `next-sitemap` will create sitemap (e.g. sitemap-1.xml, sitemap-2.xml) and index (e.g. sitemap.xml) files.
 
-## `next-sitemap.js` Options
+## Configuration Options
 
 | property                            | description                                                                                                                                                                                                                                                              | type     |
 | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
@@ -60,7 +74,7 @@ Above is the minimal configuration to split a large sitemap. When the number of 
 | outDir (optional)                   | All the generated files will be exported to this directory. Default `public`                                                                                                                                                                                             | string   |
 | transform (optional)                | A transformation function, which runs **for each** url in the sitemap. Returning `null` value from the transformation function will result in the exclusion of that specific url from the generated sitemap list.                                                        | function |
 
-## Full configuration
+## Full configuration example
 
 Here's an example `next-sitemap.js` configuration with all options
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Above is the minimal configuration to split a large sitemap. When the number of 
 | sourceDir                           | next.js build directory. Default `.next`                                                                                | string   |
 | outDir                              | All the generated files will be exported to this directory. Default `public`                                            | string   |
 
+- **siteUrl | `<string>` | `required`**: Base url of your website
+-
+- **generateRobotsTxt | `<boolean>` | `(optional)`| `Default: false`**: Generate a robots.txt file and list the generated sitemaps. Default false
+
 ## Full configuration
 
 Here's an example `next-sitemap.js` configuration with all options

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # next-sitemap
 
-Sitemap generator for next.js. `next-sitemap` will generate a sitemap file for all pages (including all pre-rendered/static pages).
+Sitemap generator for next.js. Generate sitemap(s) and robots.txt for all static/pre-rendered pages.
 
-## Install
+## Installation
 
 ```shell
 yarn add next-sitemap -D

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Sitemap generator for next.js. Generate sitemap(s) and robots.txt for all static
   - [Building sitemaps](#building-sitemaps)
 - [Splitting large sitemap into multiple files](#splitting-large-sitemap-into-multiple-files)
 - [Configuration Options](#next-sitemapjs-options)
-- [Custom transformation function](#custom-transformation-fuction)
+- [Custom transformation function](#custom-transformation-function)
 - [Full configuration example](#full-configuration-example)
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -137,8 +137,3 @@ Sitemap: https://example.com/my-custom-sitemap-1.xml
 Sitemap: https://example.com/my-custom-sitemap-2.xml
 Sitemap: https://example.com/my-custom-sitemap-3.xml
 ```
-
-## TODO
-
-- <s>Add support for splitting sitemap</s>
-- <s>Add support for `robots.txt`</s>

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Sitemap generator for next.js. Generate sitemap(s) and robots.txt for all static
   - [Building sitemaps](#building-sitemaps)
 - [Splitting large sitemap into multiple files](#splitting-large-sitemap-into-multiple-files)
 - [Configuration Options](#next-sitemapjs-options)
+- [Custom transformation function](#custom-transformation-fuction)
 - [Full configuration example](#full-configuration-example)
 
 ## Getting started
@@ -73,6 +74,38 @@ Above is the minimal configuration to split a large sitemap. When the number of 
 | sourceDir                           | next.js build directory. Default `.next`                                                                                                                                                                                                                                 | string   |
 | outDir (optional)                   | All the generated files will be exported to this directory. Default `public`                                                                                                                                                                                             | string   |
 | transform (optional)                | A transformation function, which runs **for each** url in the sitemap. Returning `null` value from the transformation function will result in the exclusion of that specific url from the generated sitemap list.                                                        | function |
+
+## Custom transformation function
+
+A transformation function, which runs **for each** url in the sitemap. Returning `null` value from the transformation function will result in the exclusion of that specific url from the generated sitemap list.
+
+```jsx
+module.exports = {
+  transform: (config, url) => {
+    // custom function to ignore the url
+    if (customIgnoreFunction(url)) {
+      return null
+    }
+
+    // only create changefreq along with url
+    // returning partial properties will result in generation of XML field with only returned values.
+    if (customLimitedField(url)) {
+      // This returns `url` & `changefreq`. Hence it will result in the generation of XML field with `url` and  `changefreq` properties only.
+      return {
+        url,
+        changefreq: 'weekly',
+      }
+    }
+
+    return {
+      url,
+      changefreq: config.changefreq,
+      priority: config.priority,
+      lastmod: config.autoLastmod ? new Date().toISOString() : undefined,
+    }
+  },
+}
+```
 
 ## Full configuration example
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ Define the `sitemapSize` property in `next-sitemap.js` to split large sitemap in
 module.exports = {
   siteUrl: 'https://example.com',
   generateRobotsTxt: true,
+  sitemapSize: 7000,
 }
 ```
 
-Above is the minimal configuration to split a large sitemap. When the number of URLs in a sitemap is more than 5000, `next-sitemap` will create sitemap (e.g. sitemap-1.xml, sitemap-2.xml) and index (e.g. sitemap.xml) files.
+Above is the minimal configuration to split a large sitemap. When the number of URLs in a sitemap is more than 7000, `next-sitemap` will create sitemap (e.g. sitemap-1.xml, sitemap-2.xml) and index (e.g. sitemap.xml) files.
 
 ## `next-sitemap.js` Options
 

--- a/README.md
+++ b/README.md
@@ -45,23 +45,20 @@ Above is the minimal configuration to split a large sitemap. When the number of 
 
 ## `next-sitemap.js` Options
 
-| property                            | description                                                                                                             | type     |
-| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | -------- |
-| siteUrl                             | Base url of your website                                                                                                | string   |
-| changefreq (optional)               | Change frequency. Default `daily`                                                                                       | string   |
-| priority (optional)                 | Priority. Default `0.7`                                                                                                 | number   |
-| sitemapSize(optional)               | Split large sitemap into multiple files by specifying sitemap size. Default `5000`                                      | number   |
-| generateRobotsTxt                   | Generate a `robots.txt` file and list the generated sitemaps. Default `false`                                           | boolean  |
-| robotsTxtOptions.policies           | Policies for generating `robots.txt`. Default to `[{ userAgent: '*', allow: '/' }`                                      | []       |
-| robotsTxtOptions.additionalSitemaps | Options to add addition sitemap to `robots.txt` host entry                                                              | string[] |
-| autoLastmod (optional)              | Add `<lastmod/>` property. Default to `true`                                                                            | true     |  |
-| exclude                             | Array of **relative** paths to exclude from listing on `sitemap.xml` or `sitemap-*.xml`. e.g.: `['/page-0', '/page-4']` | string[] |
-| sourceDir                           | next.js build directory. Default `.next`                                                                                | string   |
-| outDir                              | All the generated files will be exported to this directory. Default `public`                                            | string   |
-
-- **siteUrl | `<string>` | `required`**: Base url of your website
--
-- **generateRobotsTxt | `<boolean>` | `(optional)`| `Default: false`**: Generate a robots.txt file and list the generated sitemaps. Default false
+| property                            | description                                                                                                                                                                                                                                                              | type     |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
+| siteUrl                             | Base url of your website                                                                                                                                                                                                                                                 | string   |
+| changefreq (optional)               | Change frequency. Default `daily`                                                                                                                                                                                                                                        | string   |
+| priority (optional)                 | Priority. Default `0.7`                                                                                                                                                                                                                                                  | number   |
+| sitemapSize(optional)               | Split large sitemap into multiple files by specifying sitemap size. Default `5000`                                                                                                                                                                                       | number   |
+| generateRobotsTxt                   | Generate a `robots.txt` file and list the generated sitemaps. Default `false`                                                                                                                                                                                            | boolean  |
+| robotsTxtOptions.policies           | Policies for generating `robots.txt`. Default to `[{ userAgent: '*', allow: '/' }`                                                                                                                                                                                       | []       |
+| robotsTxtOptions.additionalSitemaps | Options to add addition sitemap to `robots.txt` host entry                                                                                                                                                                                                               | string[] |
+| autoLastmod (optional)              | Add `<lastmod/>` property. Default to `true`                                                                                                                                                                                                                             | true     |  |
+| exclude (optional)                  | Array of **relative** paths to exclude from listing on `sitemap.xml` or `sitemap-*.xml`. e.g.: `['/page-0', '/page-4']`. Apart from this options `next-sitemap` also offers a custom `transform` option which could be used to exclude urls that match specific patterns | string[] |
+| sourceDir                           | next.js build directory. Default `.next`                                                                                                                                                                                                                                 | string   |
+| outDir (optional)                   | All the generated files will be exported to this directory. Default `public`                                                                                                                                                                                             | string   |
+| transform (optional)                | A transformation function, which runs **for each** url in the sitemap. Returning `null` value from the transformation function will result in the exclusion of that specific url from the generated sitemap list.                                                        | function |
 
 ## Full configuration
 
@@ -75,6 +72,15 @@ module.exports = {
   sitemapSize: 5000,
   generateRobotsTxt: true,
   exclude: ['/protected-page', '/awesome/secret-page'],
+  // Default transformation function
+  transform: (config, url) => {
+    return {
+      url,
+      changefreq: config.changefreq,
+      priority: config.priority,
+      lastmod: config.autoLastmod ? new Date().toISOString() : undefined,
+    }
+  },
   robotsTxtOptions: {
     policies: [
       {

--- a/example/next-sitemap.js
+++ b/example/next-sitemap.js
@@ -1,6 +1,9 @@
 module.exports = {
   siteUrl: 'https://example.com',
   generateRobotsTxt: true,
+  transform: () => {
+    return null
+  },
   // optional
   robotsTxtOptions: {
     additionalSitemaps: [

--- a/example/next-sitemap.js
+++ b/example/next-sitemap.js
@@ -1,8 +1,12 @@
 module.exports = {
   siteUrl: 'https://example.com',
   generateRobotsTxt: true,
-  transform: () => {
-    return null
+  // Optional custom transformation function
+  transform: (_, url) => {
+    return {
+      url,
+      changefreq: 'yearly',
+    }
   },
   // optional
   robotsTxtOptions: {

--- a/example/package.json
+++ b/example/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^16.13.1"
   },
   "devDependencies": {
-    "@types/react": "^16.9.45",
+    "@types/react": "^16.9.49",
     "next-sitemap": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "format": "prettier --write \"**/*.{js,mjs,cjs,jsx,json,ts,tsx,md,mdx,css,html,yml,yaml,scss,less,graphql,graphqls,gql}\""
   },
   "devDependencies": {
-    "@corex/workspace": "^2.3.6"
+    "@corex/workspace": "^2.4.6"
   }
 }

--- a/packages/next-sitemap/package.json
+++ b/packages/next-sitemap/package.json
@@ -20,6 +20,6 @@
     "build:esnext": "tsc --module esnext --outDir dist/esnext"
   },
   "dependencies": {
-    "@corex/deepmerge": "^2.3.6"
+    "@corex/deepmerge": "^2.4.6"
   }
 }

--- a/packages/next-sitemap/src/config/index.test.ts
+++ b/packages/next-sitemap/src/config/index.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { defaultConfig, withDefaultConfig, transformSitemap } from '.'
 import { IConfig, ISitemapFiled } from '../interface'
 
@@ -76,7 +77,6 @@ describe('next-sitemap/config', () => {
       },
     })
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const value = myConfig.transform!(myConfig, 'https://example.com')
 
     expect(value).toStrictEqual({
@@ -95,7 +95,7 @@ describe('next-sitemap/config', () => {
       exclude: ['1', '2'],
       priority: 0.6,
       changefreq: 'weekly',
-      transform: (): Partial<ISitemapFiled> => {
+      transform: (): ISitemapFiled => {
         return {
           url: 'something-else',
           lastmod: 'lastmod-cutom',

--- a/packages/next-sitemap/src/config/index.test.ts
+++ b/packages/next-sitemap/src/config/index.test.ts
@@ -1,5 +1,5 @@
-import { defaultConfig, withDefaultConfig } from '.'
-import { IConfig } from '../interface'
+import { defaultConfig, withDefaultConfig, transformSitemap } from '.'
+import { IConfig, ISitemapFiled } from '../interface'
 
 describe('next-sitemap/config', () => {
   test('defaultConfig', () => {
@@ -11,6 +11,7 @@ describe('next-sitemap/config', () => {
       sitemapSize: 5000,
       autoLastmod: true,
       exclude: [],
+      transform: transformSitemap,
       robotsTxtOptions: {
         policies: [
           {
@@ -47,6 +48,7 @@ describe('next-sitemap/config', () => {
       autoLastmod: true,
       generateRobotsTxt: true,
       exclude: ['1', '2'],
+      transform: transformSitemap,
       robotsTxtOptions: {
         policies: [],
         additionalSitemaps: [
@@ -54,6 +56,66 @@ describe('next-sitemap/config', () => {
           'https://example.com/awesome-sitemap-2.xml',
         ],
       },
+    })
+  })
+
+  test('withDefaultConfig: default transformation', () => {
+    const myConfig = withDefaultConfig({
+      sourceDir: 'custom-source',
+      generateRobotsTxt: true,
+      sitemapSize: 50000,
+      exclude: ['1', '2'],
+      priority: 0.6,
+      changefreq: 'weekly',
+      robotsTxtOptions: {
+        policies: [],
+        additionalSitemaps: [
+          'https://example.com/awesome-sitemap.xml',
+          'https://example.com/awesome-sitemap-2.xml',
+        ],
+      },
+    })
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const value = myConfig.transform!(myConfig, 'https://example.com')
+
+    expect(value).toStrictEqual({
+      url: 'https://example.com',
+      lastmod: expect.any(String),
+      changefreq: 'weekly',
+      priority: 0.6,
+    })
+  })
+
+  test('withDefaultConfig: custom transformation', () => {
+    const myConfig = withDefaultConfig({
+      sourceDir: 'custom-source',
+      generateRobotsTxt: true,
+      sitemapSize: 50000,
+      exclude: ['1', '2'],
+      priority: 0.6,
+      changefreq: 'weekly',
+      transform: (): Partial<ISitemapFiled> => {
+        return {
+          url: 'something-else',
+          lastmod: 'lastmod-cutom',
+        }
+      },
+      robotsTxtOptions: {
+        policies: [],
+        additionalSitemaps: [
+          'https://example.com/awesome-sitemap.xml',
+          'https://example.com/awesome-sitemap-2.xml',
+        ],
+      },
+    })
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const value = myConfig.transform!(myConfig, 'https://example.com')
+
+    expect(value).toStrictEqual({
+      url: 'something-else',
+      lastmod: 'lastmod-cutom',
     })
   })
 })

--- a/packages/next-sitemap/src/config/index.ts
+++ b/packages/next-sitemap/src/config/index.ts
@@ -15,7 +15,7 @@ export const loadConfig = (path: string): IConfig => {
 export const transformSitemap = (
   config: IConfig,
   url: string
-): Partial<ISitemapFiled> => {
+): ISitemapFiled => {
   return {
     url,
     changefreq: config.changefreq,

--- a/packages/next-sitemap/src/config/index.ts
+++ b/packages/next-sitemap/src/config/index.ts
@@ -1,7 +1,28 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import fs from 'fs'
-import { IConfig } from '../interface'
+import { IConfig, ISitemapFiled } from '../interface'
 import { merge } from '@corex/deepmerge'
+
+export const loadConfig = (path: string): IConfig => {
+  if (fs.existsSync(path)) {
+    const config = require(path)
+    return withDefaultConfig(config)
+  }
+
+  throw new Error("No config file exist. Please create 'next-sitemap.js'")
+}
+
+export const transformSitemap = (
+  config: IConfig,
+  url: string
+): Partial<ISitemapFiled> => {
+  return {
+    url,
+    changefreq: config.changefreq,
+    priority: config.priority,
+    lastmod: config.autoLastmod ? new Date().toISOString() : undefined,
+  }
+}
 
 export const defaultConfig: Partial<IConfig> = {
   sourceDir: '.next',
@@ -11,6 +32,7 @@ export const defaultConfig: Partial<IConfig> = {
   sitemapSize: 5000,
   autoLastmod: true,
   exclude: [],
+  transform: transformSitemap,
   robotsTxtOptions: {
     policies: [
       {
@@ -26,13 +48,4 @@ export const withDefaultConfig = (config: Partial<IConfig>): IConfig => {
   return merge([defaultConfig, config], {
     arrayMergeType: 'overwrite',
   }) as IConfig
-}
-
-export const loadConfig = (path: string): IConfig => {
-  if (fs.existsSync(path)) {
-    const config = require(path)
-    return withDefaultConfig(config)
-  }
-
-  throw new Error("No config file exist. Please create 'next-sitemap.js'")
 }

--- a/packages/next-sitemap/src/fixtures/config.ts
+++ b/packages/next-sitemap/src/fixtures/config.ts
@@ -1,6 +1,7 @@
 import { IConfig } from '../interface'
+import { withDefaultConfig } from '../config'
 
-export const sampleConfig: IConfig = {
+export const sampleConfig: IConfig = withDefaultConfig({
   siteUrl: 'https://example.com',
   sourceDir: 'public',
   changefreq: 'daily',
@@ -24,4 +25,4 @@ export const sampleConfig: IConfig = {
       'https://example.com/my-custom-sitemap-3.xml',
     ],
   },
-}
+})

--- a/packages/next-sitemap/src/index.ts
+++ b/packages/next-sitemap/src/index.ts
@@ -29,7 +29,7 @@ const allSitemaps: string[] = []
 
 // Generate sitemaps from chunks
 sitemapChunks.forEach((chunk) => {
-  generateSitemap(config, chunk.path, chunk.urls)
+  generateSitemap(config, chunk.path, chunk.fields)
   allSitemaps.push(generateUrl(config.siteUrl, `/${chunk.filename}`))
 })
 

--- a/packages/next-sitemap/src/interface.ts
+++ b/packages/next-sitemap/src/interface.ts
@@ -20,6 +20,7 @@ export interface IConfig {
   robotsTxtOptions?: IRobotsTxt
   autoLastmod?: boolean
   exclude?: string[]
+  transform?: (config: IConfig, url: string) => Partial<ISitemapFiled>
 }
 
 export interface IBuildManifest {
@@ -51,3 +52,8 @@ export interface IRuntimePaths {
   SITEMAP_FILE: string
   ROBOTS_TXT_FILE: string
 }
+
+export type ISitemapFiled = {
+  url: string
+  lastmod?: string
+} & Pick<IConfig, 'changefreq' | 'priority'>

--- a/packages/next-sitemap/src/interface.ts
+++ b/packages/next-sitemap/src/interface.ts
@@ -20,7 +20,7 @@ export interface IConfig {
   robotsTxtOptions?: IRobotsTxt
   autoLastmod?: boolean
   exclude?: string[]
-  transform?: (config: IConfig, url: string) => Partial<ISitemapFiled>
+  transform?: (config: IConfig, url: string) => ISitemapFiled
 }
 
 export interface IBuildManifest {
@@ -42,7 +42,7 @@ export interface INextManifest {
 
 export interface ISitemapChunk {
   path: string
-  urls: string[]
+  fields: ISitemapFiled[]
   filename: string
 }
 
@@ -56,4 +56,6 @@ export interface IRuntimePaths {
 export type ISitemapFiled = {
   url: string
   lastmod?: string
-} & Pick<IConfig, 'changefreq' | 'priority'>
+  changefreq?: string
+  priority?: string
+}

--- a/packages/next-sitemap/src/path/index.ts
+++ b/packages/next-sitemap/src/path/index.ts
@@ -1,7 +1,12 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import path from 'path'
-import { ISitemapChunk, IConfig, IRuntimePaths } from '../interface'
+import {
+  ISitemapChunk,
+  IConfig,
+  IRuntimePaths,
+  ISitemapFiled,
+} from '../interface'
 
 export const getPath = (...pathSegment: string[]): string => {
   return path.resolve(process.cwd(), ...pathSegment)
@@ -9,7 +14,7 @@ export const getPath = (...pathSegment: string[]): string => {
 
 export const resolveSitemapChunks = (
   baseSitemapPath: string,
-  chunks: string[][]
+  chunks: ISitemapFiled[][]
 ): ISitemapChunk[] => {
   const folder = path.dirname(baseSitemapPath)
   return chunks.map((chunk, index) => {
@@ -17,7 +22,7 @@ export const resolveSitemapChunks = (
 
     return {
       path: `${folder}/${filename}`,
-      urls: chunk,
+      fields: chunk,
       filename,
     }
   })

--- a/packages/next-sitemap/src/sitemap/index.ts
+++ b/packages/next-sitemap/src/sitemap/index.ts
@@ -1,35 +1,42 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { IConfig } from '../interface'
+import { IConfig, ISitemapFiled } from '../interface'
 import { exportFile } from '../file'
 
 export const withXMLTemplate = (content: string): string => {
   return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">\n${content}</urlset>`
 }
 
-export const buildSitemapXml = (config: IConfig, urls: string[]): string => {
-  const content = urls.reduce((prev, curr) => {
-    const value = config.transform!(config, curr)
+export const buildSitemapXml = (
+  config: IConfig,
+  fields: ISitemapFiled[]
+): string => {
+  const content = fields
+    .reduce((prev, curr) => {
+      let field = ''
 
-    // Add location prop
-    let filed = value.url ? `<loc>${value.url}</loc>` : ''
+      if (curr) {
+        // Add location prop
+        field += curr.url ? `<loc>${curr.url}</loc>` : ''
 
-    // Add change frequency
-    filed += value.changefreq
-      ? `<changefreq>${value.changefreq}</changefreq>`
-      : ''
+        // Add change frequency
+        field += curr.changefreq
+          ? `<changefreq>${curr.changefreq}</changefreq>`
+          : ''
 
-    // Add priority
-    filed += value.priority ? `<priority>${value.priority}</priority>` : ''
+        // Add priority
+        field += curr.priority ? `<priority>${curr.priority}</priority>` : ''
 
-    // Add lastmod
-    filed += value.lastmod ? `<lastmod>${value.lastmod}</lastmod>` : ''
+        // Add lastmod
+        field += curr.lastmod ? `<lastmod>${curr.lastmod}</lastmod>` : ''
 
-    // Create url filed based on field values
-    filed = filed ? `<url>${filed}</url>` : ''
+        // Create url field based on field values
+        field = field ? `<url>${field}</url>` : ''
+      }
 
-    // Append previous value and return
-    return `${prev}${filed}\n`
-  }, '')
+      // Append previous value and return
+      return `${prev}${field}\n`
+    }, '')
+    .trim()
 
   return withXMLTemplate(content)
 }
@@ -37,8 +44,8 @@ export const buildSitemapXml = (config: IConfig, urls: string[]): string => {
 export const generateSitemap = (
   config: IConfig,
   path: string,
-  urls: string[]
+  fields: ISitemapFiled[]
 ): void => {
-  const sitemapXml = buildSitemapXml(config, urls)
+  const sitemapXml = buildSitemapXml(config, fields)
   exportFile(path, sitemapXml)
 }

--- a/packages/next-sitemap/src/sitemap/index.ts
+++ b/packages/next-sitemap/src/sitemap/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { IConfig } from '../interface'
 import { exportFile } from '../file'
 
@@ -6,17 +7,29 @@ export const withXMLTemplate = (content: string): string => {
 }
 
 export const buildSitemapXml = (config: IConfig, urls: string[]): string => {
-  const content = urls.reduce(
-    (prev, curr) =>
-      `${prev}<url><loc>${curr}</loc><changefreq>${
-        config.changefreq
-      }</changefreq><priority>${config.priority}</priority>${
-        config.autoLastmod
-          ? `<lastmod>${new Date().toISOString()}</lastmod>`
-          : ''
-      }</url>\n`,
-    ''
-  )
+  const content = urls.reduce((prev, curr) => {
+    const value = config.transform!(config, curr)
+
+    // Add location prop
+    let filed = value.url ? `<loc>${value.url}</loc>` : ''
+
+    // Add change frequency
+    filed += value.changefreq
+      ? `<changefreq>${value.changefreq}</changefreq>`
+      : ''
+
+    // Add priority
+    filed += value.priority ? `<priority>${value.priority}</priority>` : ''
+
+    // Add lastmod
+    filed += value.lastmod ? `<lastmod>${value.lastmod}</lastmod>` : ''
+
+    // Create url filed based on field values
+    filed = filed ? `<url>${filed}</url>` : ''
+
+    // Append previous value and return
+    return `${prev}${filed}\n`
+  }, '')
 
   return withXMLTemplate(content)
 }

--- a/packages/next-sitemap/src/url/create-url-set/index.test.ts
+++ b/packages/next-sitemap/src/url/create-url-set/index.test.ts
@@ -6,11 +6,36 @@ describe('next-sitemap/createUrlSet', () => {
   test('without exclusion', () => {
     const urlset = createUrlSet(sampleConfig, sampleManifest)
     expect(urlset).toStrictEqual([
-      'https://example.com/',
-      'https://example.com/page-0',
-      'https://example.com/page-1',
-      'https://example.com/page-2',
-      'https://example.com/page-3',
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        url: 'https://example.com/',
+      },
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        url: 'https://example.com/page-0',
+      },
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        url: 'https://example.com/page-1',
+      },
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        url: 'https://example.com/page-2',
+      },
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        url: 'https://example.com/page-3',
+      },
     ])
   })
 
@@ -24,8 +49,18 @@ describe('next-sitemap/createUrlSet', () => {
     )
 
     expect(urlset).toStrictEqual([
-      'https://example.com/page-1',
-      'https://example.com/page-3',
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        url: 'https://example.com/page-1',
+      },
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        url: 'https://example.com/page-3',
+      },
     ])
   })
 })

--- a/packages/next-sitemap/src/url/create-url-set/index.ts
+++ b/packages/next-sitemap/src/url/create-url-set/index.ts
@@ -1,4 +1,5 @@
-import { IConfig, INextManifest } from '../../interface'
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { IConfig, INextManifest, ISitemapFiled } from '../../interface'
 import { isNextInternalUrl, generateUrl } from '../util'
 import { removeFromArray } from '../../array'
 
@@ -10,7 +11,7 @@ import { removeFromArray } from '../../array'
 export const createUrlSet = (
   config: IConfig,
   manifest: INextManifest
-): string[] => {
+): ISitemapFiled[] => {
   let allKeys = [
     ...Object.keys(manifest.build.pages),
     ...(manifest.preRender ? Object.keys(manifest.preRender.routes) : []),
@@ -22,9 +23,16 @@ export const createUrlSet = (
   }
 
   // Filter out next.js internal urls and generate urls based on sitemap
-  const urlSet = allKeys
+  let urlSet = allKeys
     .filter((x) => !isNextInternalUrl(x))
     .map((x) => generateUrl(config.siteUrl, x))
 
-  return [...new Set(urlSet)]
+  urlSet = [...new Set(urlSet)]
+
+  // Create sitemap fields based on transformation
+  const sitemapFields = urlSet
+    .map((url) => config.transform!(config, url))
+    .filter((x) => x !== null)
+
+  return sitemapFields
 }

--- a/packages/next-sitemap/src/url/create-url-set/index.ts
+++ b/packages/next-sitemap/src/url/create-url-set/index.ts
@@ -21,7 +21,7 @@ export const createUrlSet = (
     allKeys = removeFromArray(allKeys, config.exclude)
   }
 
-  // Node10 support
+  // Filter out next.js internal urls and generate urls based on sitemap
   const urlSet = allKeys
     .filter((x) => !isNextInternalUrl(x))
     .map((x) => generateUrl(config.siteUrl, x))

--- a/packages/next-sitemap/src/url/create-url-set/index.ts
+++ b/packages/next-sitemap/src/url/create-url-set/index.ts
@@ -23,16 +23,18 @@ export const createUrlSet = (
   }
 
   // Filter out next.js internal urls and generate urls based on sitemap
-  let urlSet = allKeys
-    .filter((x) => !isNextInternalUrl(x))
-    .map((x) => generateUrl(config.siteUrl, x))
+  let urlSet = allKeys.filter((x) => !isNextInternalUrl(x))
 
   urlSet = [...new Set(urlSet)]
 
   // Create sitemap fields based on transformation
   const sitemapFields = urlSet
-    .map((url) => config.transform!(config, url))
-    .filter((x) => x !== null)
+    .map((url) => config.transform!(config, url)) // transform using relative urls
+    .filter((x) => x !== null) // remove null values
+    .map((x) => ({
+      ...x,
+      url: generateUrl(config.siteUrl, x.url), // create absolute urls based on sitemap fields
+    }))
 
   return sitemapFields
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1092,10 +1092,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@corex/deepmerge@^2.3.6":
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/@corex/deepmerge/-/deepmerge-2.3.6.tgz#1301b0e43cc692e26ccf5d41fc6642446a9b212b"
-  integrity sha512-YziRFUyFj+fKWPkfs6iPFnjf++KYvO+XAQ6yKIzswW5fiudrhMo0mE9eVWYiVDRM95bmVnX3JQbRA8HwqDosPA==
+"@corex/deepmerge@^2.4.6":
+  version "2.4.6"
+  resolved "https://registry.yarnpkg.com/@corex/deepmerge/-/deepmerge-2.4.6.tgz#0dfc3973f41e88862825e8a2f1eb5f84ca5fe564"
+  integrity sha512-iSp8KAgtQBZpUrOnaKkn2oRMsSru50g5saizb4ZwGHccFylH7XrNvzuf86M94O/uqNkk9NxaCbkVC372ms2RPQ==
 
 "@corex/eslint-config@*":
   version "2.3.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,10 +1151,10 @@
   dependencies:
     typescript "3.9.7"
 
-"@corex/workspace@^2.3.6":
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/@corex/workspace/-/workspace-2.3.6.tgz#db4a3935c9309b0540c944bb24a8680cbec45a2b"
-  integrity sha512-LGMANysiTkBQzHU7R82XAWVBO1XK6gvR3RIetS7RnqL+sMWSAuo+UV8L8vXwsA3+Zu8EzbLAQg69Pf108dxgeQ==
+"@corex/workspace@^2.4.6":
+  version "2.4.6"
+  resolved "https://registry.yarnpkg.com/@corex/workspace/-/workspace-2.4.6.tgz#6dcdfbeb95c5857e2878e48e21172842bd44faf2"
+  integrity sha512-9ISodvcXvrEPVh6gUmGe/CD4Jfgo+MOU6lJMLqiF3/k/GH3hUXlCU4BJptKWNrntIhDwx2/hmAtLRzbNnQcLMg==
   dependencies:
     "@corex/eslint-config" "*"
     "@corex/jest" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1605,10 +1605,10 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/react@^16.9.45":
-  version "16.9.46"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.46.tgz#f0326cd7adceda74148baa9bff6e918632f5069e"
-  integrity sha512-dbHzO3aAq1lB3jRQuNpuZ/mnu+CdD3H0WVaaBQA8LTT3S33xhVBUj232T8M3tAhSWJs/D/UqORYUlJNl/8VQZg==
+"@types/react@^16.9.49":
+  version "16.9.49"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.49.tgz#09db021cf8089aba0cdb12a49f8021a69cce4872"
+  integrity sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"


### PR DESCRIPTION
Added support for url transformation to create XML field for individual urls. This provides custom configuration(`changefreq`, `priority`, `lastmod`) for each urls.

Returning a null value from url transformation will result in skipping that particular url. Hence transform option can be used for excluding wildcard url patterns as well. 

Ref: #28 