### PR TITLE
Consider /404 a Next internal URL

### DIFF
--- a/packages/next-sitemap/src/url/util/index.test.ts
+++ b/packages/next-sitemap/src/url/util/index.test.ts
@@ -48,5 +48,6 @@ describe('next-sitemap', () => {
     expect(isNextInternalUrl('/some_url/[param]')).toBeTruthy()
 
     expect(isNextInternalUrl('/some_url')).toBeFalsy()
+    expect(isNextInternalUrl('/some-404')).toBeFalsy()
   })
 })

--- a/packages/next-sitemap/src/url/util/index.test.ts
+++ b/packages/next-sitemap/src/url/util/index.test.ts
@@ -34,6 +34,7 @@ describe('next-sitemap', () => {
 
   test('isNextInternalUrl', () => {
     expect(isNextInternalUrl('/_app')).toBeTruthy()
+    expect(isNextInternalUrl('/404')).toBeTruthy()
     expect(isNextInternalUrl('/_random')).toBeTruthy()
   })
 

--- a/packages/next-sitemap/src/url/util/index.ts
+++ b/packages/next-sitemap/src/url/util/index.ts
@@ -18,5 +18,5 @@ export const generateUrl = (baseUrl: string, slug: string): string => {
  * @param path path check
  */
 export const isNextInternalUrl = (path: string): boolean => {
-  return new RegExp(/[^\/]*^.[_]|404$|(?:\[)/g).test(path)
+  return new RegExp(/[^\/]*^.[_]|^\/404$|(?:\[)/g).test(path)
 }

--- a/packages/next-sitemap/src/url/util/index.ts
+++ b/packages/next-sitemap/src/url/util/index.ts
@@ -18,5 +18,5 @@ export const generateUrl = (baseUrl: string, slug: string): string => {
  * @param path path check
  */
 export const isNextInternalUrl = (path: string): boolean => {
-  return new RegExp(/[^\/]*^.[_]|(?:\[)/g).test(path)
+  return new RegExp(/[^\/]*^.[_]|404$|(?:\[)/g).test(path)
 }


### PR DESCRIPTION
Next.js [uses a page at /404.js](https://nextjs.org/docs/advanced-features/custom-error-page#customizing-the-404-page) as a custom "404 not found" page for when a user navigates to any page that doesn't exist.

It should probably not be included in the sitemap, since when Google tries to crawl it, it seems to think that /404 doesn't actually exist. I've been getting errors in my Google Search Console's coverage reports indicating this (see below).

![Screen Shot 2020-12-29 at 3 27 56 PM](https://user-images.githubusercontent.com/1216917/103320580-b30bc500-49ea-11eb-9547-a3bc1edddbb9.png)

For now, I'm just manually excluding `/404` in my `next-sitemap` config, but this seemed like a reasonable upstream change to make. Let me know what you think!