### PR TITLE
Adds support for hreflang, spelling fixes, performance updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,14 @@ module.exports = {
   generateRobotsTxt: true,
   exclude: ['/protected-page', '/awesome/secret-page'],
   alternateRefs: [
-    { href: 'https://es.example.com', hreflang: 'es' },
-    { href: 'https://fr.example.com', hreflang: 'fr' }
+    {
+      href: 'https://es.example.com',
+      hreflang: 'es',
+    },
+    {
+      href: 'https://fr.example.com',
+      hreflang: 'fr',
+    },
   ],
   // Default transformation function
   transform: async (config, path) => {

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Above is the minimal configuration to split a large sitemap. When the number of 
 | siteUrl                                        | Base url of your website                                                                                                                                                                                                                                                                                                                                          | string         |
 | changefreq (optional)                          | Change frequency. Default `daily`                                                                                                                                                                                                                                                                                                                                 | string         |
 | priority (optional)                            | Priority. Default `0.7`                                                                                                                                                                                                                                                                                                                                           | number         |
+| alternateRefs (optional)                       | Denote multi-language support by unique URL. Default `[]`                                                                                                                                                                                                                                                                                                         | AlternateRef[] |
 | sitemapSize(optional)                          | Split large sitemap into multiple files by specifying sitemap size. Default `5000`                                                                                                                                                                                                                                                                                | number         |
 | generateRobotsTxt (optional)                   | Generate a `robots.txt` file and list the generated sitemaps. Default `false`                                                                                                                                                                                                                                                                                     | boolean        |
 | robotsTxtOptions.policies (optional)           | Policies for generating `robots.txt`. Default `[{ userAgent: '*', allow: '/' }]`                                                                                                                                                                                                                                                                                  | []             |
@@ -117,6 +118,7 @@ module.exports = {
       changefreq: config.changefreq,
       priority: config.priority,
       lastmod: config.autoLastmod ? new Date().toISOString() : undefined,
+      alternateRefs: config.alternateRefs ?? [],
     }
   },
 }
@@ -134,6 +136,10 @@ module.exports = {
   sitemapSize: 5000,
   generateRobotsTxt: true,
   exclude: ['/protected-page', '/awesome/secret-page'],
+  alternateRefs: [
+    { href: 'https://es.example.com', hreflang: 'es' },
+    { href: 'https://fr.example.com', hreflang: 'fr' }
+  ],
   // Default transformation function
   transform: async (config, path) => {
     return {
@@ -141,6 +147,7 @@ module.exports = {
       changefreq: config.changefreq,
       priority: config.priority,
       lastmod: config.autoLastmod ? new Date().toISOString() : undefined,
+      alternateRefs: config.alternateRefs ?? [],
     }
   },
   robotsTxtOptions: {

--- a/packages/next-sitemap/src/config/index.test.ts
+++ b/packages/next-sitemap/src/config/index.test.ts
@@ -86,6 +86,7 @@ describe('next-sitemap/config', () => {
       lastmod: expect.any(String),
       changefreq: 'weekly',
       priority: 0.6,
+      alternateRefs: [],
     })
   })
 

--- a/packages/next-sitemap/src/config/index.test.ts
+++ b/packages/next-sitemap/src/config/index.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { defaultConfig, withDefaultConfig, transformSitemap } from '.'
-import { IConfig, ISitemapFiled } from '../interface'
+import { IConfig, ISitemapField } from '../interface'
 
 describe('next-sitemap/config', () => {
   test('defaultConfig', () => {
@@ -97,7 +97,7 @@ describe('next-sitemap/config', () => {
       exclude: ['1', '2'],
       priority: 0.6,
       changefreq: 'weekly',
-      transform: async (): Promise<ISitemapFiled> => {
+      transform: async (): Promise<ISitemapField> => {
         return {
           loc: 'something-else',
           lastmod: 'lastmod-cutom',

--- a/packages/next-sitemap/src/config/index.ts
+++ b/packages/next-sitemap/src/config/index.ts
@@ -8,6 +8,7 @@ import {
 } from '../interface'
 import { merge } from '@corex/deepmerge'
 import { loadFile } from '../file'
+import { absoluteUrl } from '../url'
 
 export const loadConfig = (path: string): IConfig => {
   const baseConfig = loadFile<IConfig>(path)
@@ -23,6 +24,7 @@ export const transformSitemap = async (
     changefreq: config?.changefreq,
     priority: config?.priority,
     lastmod: config?.autoLastmod ? new Date().toISOString() : undefined,
+    alternateRefs: config.alternateRefs ?? [],
   }
 }
 

--- a/packages/next-sitemap/src/config/index.ts
+++ b/packages/next-sitemap/src/config/index.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import {
   IConfig,
-  ISitemapFiled,
+  ISitemapField,
   IRuntimePaths,
   IExportMarker,
 } from '../interface'
@@ -17,7 +17,7 @@ export const loadConfig = (path: string): IConfig => {
 export const transformSitemap = async (
   config: IConfig,
   url: string
-): Promise<ISitemapFiled> => {
+): Promise<ISitemapField> => {
   return {
     loc: url,
     changefreq: config?.changefreq,

--- a/packages/next-sitemap/src/config/index.ts
+++ b/packages/next-sitemap/src/config/index.ts
@@ -8,7 +8,6 @@ import {
 } from '../interface'
 import { merge } from '@corex/deepmerge'
 import { loadFile } from '../file'
-import { absoluteUrl } from '../url'
 
 export const loadConfig = (path: string): IConfig => {
   const baseConfig = loadFile<IConfig>(path)

--- a/packages/next-sitemap/src/dynamic-sitemap/getServerSideSitemap.ts
+++ b/packages/next-sitemap/src/dynamic-sitemap/getServerSideSitemap.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import { ISitemapFiled } from '../interface'
+import { ISitemapField } from '../interface'
 import { buildSitemapXml } from '../sitemap/buildSitemapXml'
 
 export const getServerSideSitemap = async (
   context: import('next').GetServerSidePropsContext,
-  fields: ISitemapFiled[]
+  fields: ISitemapField[]
 ) => {
   const sitemapContent = buildSitemapXml(fields)
 

--- a/packages/next-sitemap/src/interface.ts
+++ b/packages/next-sitemap/src/interface.ts
@@ -59,9 +59,15 @@ export interface IRuntimePaths {
   EXPORT_MARKER: string
 }
 
+export type AlternateRef = {
+  href: string
+  hreflang: string
+}
+
 export type ISitemapField = {
   loc: string
   lastmod?: string
   changefreq?: string
   priority?: string
+  alternateRefs?: Array<AlternateRef>
 }

--- a/packages/next-sitemap/src/interface.ts
+++ b/packages/next-sitemap/src/interface.ts
@@ -20,6 +20,7 @@ export interface IConfig {
   robotsTxtOptions?: IRobotsTxt
   autoLastmod?: boolean
   exclude?: string[]
+  alternateRefs?: Array<AlternateRef>
   transform?: (config: IConfig, url: string) => Promise<ISitemapField>
   trailingSlash?: boolean
 }

--- a/packages/next-sitemap/src/interface.ts
+++ b/packages/next-sitemap/src/interface.ts
@@ -20,7 +20,7 @@ export interface IConfig {
   robotsTxtOptions?: IRobotsTxt
   autoLastmod?: boolean
   exclude?: string[]
-  transform?: (config: IConfig, url: string) => Promise<ISitemapFiled>
+  transform?: (config: IConfig, url: string) => Promise<ISitemapField>
   trailingSlash?: boolean
 }
 
@@ -47,7 +47,7 @@ export interface INextManifest {
 
 export interface ISitemapChunk {
   path: string
-  fields: ISitemapFiled[]
+  fields: ISitemapField[]
   filename: string
 }
 
@@ -59,7 +59,7 @@ export interface IRuntimePaths {
   EXPORT_MARKER: string
 }
 
-export type ISitemapFiled = {
+export type ISitemapField = {
   loc: string
   lastmod?: string
   changefreq?: string

--- a/packages/next-sitemap/src/path/index.ts
+++ b/packages/next-sitemap/src/path/index.ts
@@ -5,7 +5,7 @@ import {
   ISitemapChunk,
   IConfig,
   IRuntimePaths,
-  ISitemapFiled,
+  ISitemapField,
 } from '../interface'
 import minimist from 'minimist'
 import fs from 'fs'
@@ -16,7 +16,7 @@ export const getPath = (...pathSegment: string[]): string => {
 
 export const resolveSitemapChunks = (
   baseSitemapPath: string,
-  chunks: ISitemapFiled[][]
+  chunks: ISitemapField[][]
 ): ISitemapChunk[] => {
   const folder = path.dirname(baseSitemapPath)
   return chunks.map((chunk, index) => {

--- a/packages/next-sitemap/src/sitemap/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/next-sitemap/src/sitemap/__tests__/__snapshots__/index.test.ts.snap
@@ -4,6 +4,6 @@ exports[`buildSitemapXml snapshot test to exclude undefined values from final si
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <urlset xmlns=\\"http://www.sitemaps.org/schemas/sitemap/0.9\\" xmlns:news=\\"http://www.google.com/schemas/sitemap-news/0.9\\" xmlns:xhtml=\\"http://www.w3.org/1999/xhtml\\" xmlns:mobile=\\"http://www.google.com/schemas/sitemap-mobile/1.0\\" xmlns:image=\\"http://www.google.com/schemas/sitemap-image/1.1\\" xmlns:video=\\"http://www.google.com/schemas/sitemap-video/1.1\\">
 <url><loc>https://example.com</loc></url>
-<url><loc>https://example.com</loc><lastmod>some-value</lastmod></url>
+<url><loc>https://example.com</loc><lastmod>some-value</lastmod><xhtml:link rel=\\"alternate\\" hreflang=\\"en\\" href=\\"https://example.com/en\\"/><xhtml:link rel=\\"alternate\\" hreflang=\\"fr\\" href=\\"https://example.com/fr\\"/></url>
 </urlset>"
 `;

--- a/packages/next-sitemap/src/sitemap/__tests__/index.test.ts
+++ b/packages/next-sitemap/src/sitemap/__tests__/index.test.ts
@@ -1,10 +1,10 @@
-import { ISitemapFiled } from '../../interface'
+import { ISitemapField } from '../../interface'
 import { buildSitemapXml } from '../buildSitemapXml'
 
 describe('buildSitemapXml', () => {
   test('snapshot test to exclude undefined values from final sitemap', () => {
     // Sample fields
-    const fields: ISitemapFiled[] = [
+    const fields: ISitemapField[] = [
       {
         loc: 'https://example.com',
         lastmod: undefined,

--- a/packages/next-sitemap/src/sitemap/__tests__/index.test.ts
+++ b/packages/next-sitemap/src/sitemap/__tests__/index.test.ts
@@ -12,6 +12,16 @@ describe('buildSitemapXml', () => {
       {
         loc: 'https://example.com',
         lastmod: 'some-value',
+        alternateRefs: [
+          {
+            href: "https://example.com/en",
+            hreflang: "en"
+          },
+          {
+            href: "https://example.com/fr",
+            hreflang: "fr"
+          }
+        ]
       },
     ]
 

--- a/packages/next-sitemap/src/sitemap/__tests__/index.test.ts
+++ b/packages/next-sitemap/src/sitemap/__tests__/index.test.ts
@@ -14,14 +14,14 @@ describe('buildSitemapXml', () => {
         lastmod: 'some-value',
         alternateRefs: [
           {
-            href: "https://example.com/en",
-            hreflang: "en"
+            href: 'https://example.com/en',
+            hreflang: 'en',
           },
           {
-            href: "https://example.com/fr",
-            hreflang: "fr"
-          }
-        ]
+            href: 'https://example.com/fr',
+            hreflang: 'fr',
+          },
+        ],
       },
     ]
 

--- a/packages/next-sitemap/src/sitemap/buildSitemapXml.ts
+++ b/packages/next-sitemap/src/sitemap/buildSitemapXml.ts
@@ -2,19 +2,19 @@ import { ISitemapFiled } from '../interface'
 import { withXMLTemplate } from './withXMLTemplate'
 
 export const buildSitemapXml = (fields: ISitemapFiled[]): string => {
-  const content = fields.reduce((prev, curr) => {
-    let field = ''
+  const content = fields.map(fieldData => {
+    const field: Array<string> = [];
 
     // Iterate all object keys and key value pair to field-set
-    for (const key of Object.keys(curr)) {
-      if (curr[key]) {
-        field += `<${key}>${curr[key]}</${key}>`
+    for (const key of Object.keys(fieldData)) {
+      if (fieldData[key]) {
+        field.push(`<${key}>${fieldData[key]}</${key}>`);
       }
     }
 
     // Append previous value and return
-    return `${prev}<url>${field}</url>\n`
-  }, '')
+    return `<url>${field.join("")}</url>\n`
+  }).join("");
 
   return withXMLTemplate(content)
 }

--- a/packages/next-sitemap/src/sitemap/buildSitemapXml.ts
+++ b/packages/next-sitemap/src/sitemap/buildSitemapXml.ts
@@ -12,7 +12,7 @@ export const buildSitemapXml = (fields: ISitemapField[]): string => {
           if (key !== 'alternateRefs') {
             field.push(`<${key}>${fieldData[key]}</${key}>`)
           } else {
-            field.push(buildAlternateRefsXml(fieldData.alternateRefs ?? []))
+            field.push(buildAlternateRefsXml(fieldData.alternateRefs))
           }
         }
       }
@@ -26,7 +26,7 @@ export const buildSitemapXml = (fields: ISitemapField[]): string => {
 }
 
 export const buildAlternateRefsXml = (
-  alternateRefs: Array<AlternateRef>
+  alternateRefs: Array<AlternateRef> = []
 ): string => {
   return alternateRefs
     .map((alternateRef) => {

--- a/packages/next-sitemap/src/sitemap/buildSitemapXml.ts
+++ b/packages/next-sitemap/src/sitemap/buildSitemapXml.ts
@@ -1,7 +1,7 @@
-import { ISitemapFiled } from '../interface'
+import { ISitemapField } from '../interface'
 import { withXMLTemplate } from './withXMLTemplate'
 
-export const buildSitemapXml = (fields: ISitemapFiled[]): string => {
+export const buildSitemapXml = (fields: ISitemapField[]): string => {
   const content = fields.map(fieldData => {
     const field: Array<string> = [];
 

--- a/packages/next-sitemap/src/sitemap/buildSitemapXml.ts
+++ b/packages/next-sitemap/src/sitemap/buildSitemapXml.ts
@@ -1,4 +1,4 @@
-import { ISitemapField } from '../interface'
+import { AlternateRef, ISitemapField } from '../interface'
 import { withXMLTemplate } from './withXMLTemplate'
 
 export const buildSitemapXml = (fields: ISitemapField[]): string => {
@@ -8,7 +8,11 @@ export const buildSitemapXml = (fields: ISitemapField[]): string => {
     // Iterate all object keys and key value pair to field-set
     for (const key of Object.keys(fieldData)) {
       if (fieldData[key]) {
-        field.push(`<${key}>${fieldData[key]}</${key}>`);
+        if (key !== "alternateRefs") {
+          field.push(`<${key}>${fieldData[key]}</${key}>`);
+        } else {
+          field.push(buildAlternateRefsXml(fieldData.alternateRefs ?? []))
+        }
       }
     }
 
@@ -17,4 +21,10 @@ export const buildSitemapXml = (fields: ISitemapField[]): string => {
   }).join("");
 
   return withXMLTemplate(content)
+}
+
+export const buildAlternateRefsXml = (alternateRefs: Array<AlternateRef>): string => {
+  return alternateRefs.map(alternateRef => {
+    return `<xhtml:link rel="alternate" hreflang="${alternateRef.hreflang}" href="${alternateRef.href}"/>`
+  }).join("");
 }

--- a/packages/next-sitemap/src/sitemap/buildSitemapXml.ts
+++ b/packages/next-sitemap/src/sitemap/buildSitemapXml.ts
@@ -2,29 +2,35 @@ import { AlternateRef, ISitemapField } from '../interface'
 import { withXMLTemplate } from './withXMLTemplate'
 
 export const buildSitemapXml = (fields: ISitemapField[]): string => {
-  const content = fields.map(fieldData => {
-    const field: Array<string> = [];
+  const content = fields
+    .map((fieldData) => {
+      const field: Array<string> = []
 
-    // Iterate all object keys and key value pair to field-set
-    for (const key of Object.keys(fieldData)) {
-      if (fieldData[key]) {
-        if (key !== "alternateRefs") {
-          field.push(`<${key}>${fieldData[key]}</${key}>`);
-        } else {
-          field.push(buildAlternateRefsXml(fieldData.alternateRefs ?? []))
+      // Iterate all object keys and key value pair to field-set
+      for (const key of Object.keys(fieldData)) {
+        if (fieldData[key]) {
+          if (key !== 'alternateRefs') {
+            field.push(`<${key}>${fieldData[key]}</${key}>`)
+          } else {
+            field.push(buildAlternateRefsXml(fieldData.alternateRefs ?? []))
+          }
         }
       }
-    }
 
-    // Append previous value and return
-    return `<url>${field.join("")}</url>\n`
-  }).join("");
+      // Append previous value and return
+      return `<url>${field.join('')}</url>\n`
+    })
+    .join('')
 
   return withXMLTemplate(content)
 }
 
-export const buildAlternateRefsXml = (alternateRefs: Array<AlternateRef>): string => {
-  return alternateRefs.map(alternateRef => {
-    return `<xhtml:link rel="alternate" hreflang="${alternateRef.hreflang}" href="${alternateRef.href}"/>`
-  }).join("");
+export const buildAlternateRefsXml = (
+  alternateRefs: Array<AlternateRef>
+): string => {
+  return alternateRefs
+    .map((alternateRef) => {
+      return `<xhtml:link rel="alternate" hreflang="${alternateRef.hreflang}" href="${alternateRef.href}"/>`
+    })
+    .join('')
 }

--- a/packages/next-sitemap/src/url/create-url-set/__tests__/create-url-set.test.ts
+++ b/packages/next-sitemap/src/url/create-url-set/__tests__/create-url-set.test.ts
@@ -11,30 +11,35 @@ describe('createUrlSet', () => {
         lastmod: expect.any(String),
         priority: 0.7,
         loc: 'https://example.com',
+        alternateRefs: [],
       },
       {
         changefreq: 'daily',
         lastmod: expect.any(String),
         priority: 0.7,
         loc: 'https://example.com/page-0',
+        alternateRefs: [],
       },
       {
         changefreq: 'daily',
         lastmod: expect.any(String),
         priority: 0.7,
         loc: 'https://example.com/page-1',
+        alternateRefs: [],
       },
       {
         changefreq: 'daily',
         lastmod: expect.any(String),
         priority: 0.7,
         loc: 'https://example.com/page-2',
+        alternateRefs: [],
       },
       {
         changefreq: 'daily',
         lastmod: expect.any(String),
         priority: 0.7,
         loc: 'https://example.com/page-3',
+        alternateRefs: [],
       },
     ])
   })
@@ -54,12 +59,14 @@ describe('createUrlSet', () => {
         lastmod: expect.any(String),
         priority: 0.7,
         loc: 'https://example.com/page-1',
+        alternateRefs: [],
       },
       {
         changefreq: 'daily',
         lastmod: expect.any(String),
         priority: 0.7,
         loc: 'https://example.com/page-3',
+        alternateRefs: [],
       },
     ])
   })
@@ -79,6 +86,7 @@ describe('createUrlSet', () => {
         lastmod: expect.any(String),
         priority: 0.7,
         loc: 'https://example.com',
+        alternateRefs: [],
       },
     ])
   })
@@ -97,30 +105,35 @@ describe('createUrlSet', () => {
         lastmod: expect.any(String),
         priority: 0.7,
         loc: 'https://example.com',
+        alternateRefs: [],
       },
       {
         changefreq: 'daily',
         lastmod: expect.any(String),
         priority: 0.7,
         loc: 'https://example.com/page-0',
+        alternateRefs: [],
       },
       {
         changefreq: 'daily',
         lastmod: expect.any(String),
         priority: 0.7,
         loc: 'https://example.com/page-1',
+        alternateRefs: [],
       },
       {
         changefreq: 'daily',
         lastmod: expect.any(String),
         priority: 0.7,
         loc: 'https://example.com/page-2',
+        alternateRefs: [],
       },
       {
         changefreq: 'daily',
         lastmod: expect.any(String),
         priority: 0.7,
         loc: 'https://example.com/page-3',
+        alternateRefs: [],
       },
     ])
   })
@@ -139,30 +152,35 @@ describe('createUrlSet', () => {
         lastmod: expect.any(String),
         priority: 0.7,
         loc: 'https://example.com/',
+        alternateRefs: [],
       },
       {
         changefreq: 'daily',
         lastmod: expect.any(String),
         priority: 0.7,
         loc: 'https://example.com/page-0/',
+        alternateRefs: [],
       },
       {
         changefreq: 'daily',
         lastmod: expect.any(String),
         priority: 0.7,
         loc: 'https://example.com/page-1/',
+        alternateRefs: [],
       },
       {
         changefreq: 'daily',
         lastmod: expect.any(String),
         priority: 0.7,
         loc: 'https://example.com/page-2/',
+        alternateRefs: [],
       },
       {
         changefreq: 'daily',
         lastmod: expect.any(String),
         priority: 0.7,
         loc: 'https://example.com/page-3/',
+        alternateRefs: [],
       },
     ])
   })
@@ -190,10 +208,79 @@ describe('createUrlSet', () => {
       {
         changefreq: 'yearly',
         loc: 'https://example.com/',
+        alternateRefs: [],
       },
       {
         changefreq: 'yearly',
         loc: 'https://example.com/page-2/',
+        alternateRefs: [],
+      },
+    ])
+  })
+
+  test('with alternateRefs', async () => {
+    const urlset = await createUrlSet(
+      {
+        ...sampleConfig,
+        siteUrl: 'https://example.com/',
+        alternateRefs: [
+          { href: 'https://en.example.com/', hreflang: 'en' },
+          { href: 'https://fr.example.com/', hreflang: 'fr' },
+        ],
+      },
+      sampleManifest
+    )
+
+    expect(urlset).toStrictEqual([
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        loc: 'https://example.com',
+        alternateRefs: [
+          { href: 'https://en.example.com', hreflang: 'en' },
+          { href: 'https://fr.example.com', hreflang: 'fr' },
+        ],
+      },
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        loc: 'https://example.com/page-0',
+        alternateRefs: [
+          { href: 'https://en.example.com/page-0', hreflang: 'en' },
+          { href: 'https://fr.example.com/page-0', hreflang: 'fr' },
+        ],
+      },
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        loc: 'https://example.com/page-1',
+        alternateRefs: [
+          { href: 'https://en.example.com/page-1', hreflang: 'en' },
+          { href: 'https://fr.example.com/page-1', hreflang: 'fr' },
+        ],
+      },
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        loc: 'https://example.com/page-2',
+        alternateRefs: [
+          { href: 'https://en.example.com/page-2', hreflang: 'en' },
+          { href: 'https://fr.example.com/page-2', hreflang: 'fr' },
+        ],
+      },
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        loc: 'https://example.com/page-3',
+        alternateRefs: [
+          { href: 'https://en.example.com/page-3', hreflang: 'en' },
+          { href: 'https://fr.example.com/page-3', hreflang: 'fr' },
+        ],
       },
     ])
   })

--- a/packages/next-sitemap/src/url/create-url-set/index.ts
+++ b/packages/next-sitemap/src/url/create-url-set/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { IConfig, INextManifest, ISitemapFiled } from '../../interface'
+import { IConfig, INextManifest, ISitemapField } from '../../interface'
 import { isNextInternalUrl, generateUrl } from '../util'
 import { removeIfMatchPattern } from '../../array'
 
@@ -25,7 +25,7 @@ export const absoluteUrl = (
 export const createUrlSet = async (
   config: IConfig,
   manifest: INextManifest
-): Promise<ISitemapFiled[]> => {
+): Promise<ISitemapField[]> => {
   let allKeys = [
     ...Object.keys(manifest.build.pages),
     ...(manifest.preRender ? Object.keys(manifest.preRender.routes) : []),
@@ -42,7 +42,7 @@ export const createUrlSet = async (
   urlSet = [...new Set(urlSet)]
 
   // Create sitemap fields based on transformation
-  let sitemapFields: ISitemapFiled[] = [] // transform using relative urls
+  let sitemapFields: ISitemapField[] = [] // transform using relative urls
 
   for (const url of urlSet) {
     const sitemapFiled = await config.transform!(config, url)

--- a/packages/next-sitemap/src/url/create-url-set/index.ts
+++ b/packages/next-sitemap/src/url/create-url-set/index.ts
@@ -45,8 +45,8 @@ export const createUrlSet = async (
   let sitemapFields: ISitemapField[] = [] // transform using relative urls
 
   for (const url of urlSet) {
-    const sitemapFiled = await config.transform!(config, url)
-    sitemapFields.push(sitemapFiled)
+    const sitemapField = await config.transform!(config, url)
+    sitemapFields.push(sitemapField)
   }
 
   sitemapFields = sitemapFields
@@ -54,6 +54,10 @@ export const createUrlSet = async (
     .map((x) => ({
       ...x,
       loc: absoluteUrl(config.siteUrl, x.loc, config.trailingSlash), // create absolute urls based on sitemap fields
+      alternateRefs: (x.alternateRefs ?? []).map((alternateRef) => ({
+        href: absoluteUrl(alternateRef.href, x.loc, config.trailingSlash),
+        hreflang: alternateRef.hreflang,
+      })),
     }))
 
   return sitemapFields


### PR DESCRIPTION
This adds support for the hreflang tag (Fixes #152 ), so that your Sitemap can identify that it supports multiple languages to web-crawlers.

Documentation for that syntax is here:
https://developers.google.com/search/docs/advanced/crawling/localized-versions#sitemap

Other items
* The type `ISitemapField` was misspelled as `ISitemapFiled`.
* The constant rebuilding and the garbage collecting of strings when building XML can be very innefficient.  I converted this logic from `Array.reduce(...)` to `Array.map(...).join("")`