### PR TITLE
Added header options for getServerSideSitemap

### DIFF
--- a/packages/next-sitemap/src/dynamic-sitemap/getServerSideSitemap.test.ts
+++ b/packages/next-sitemap/src/dynamic-sitemap/getServerSideSitemap.test.ts
@@ -1,0 +1,48 @@
+import type {
+  GetServerSidePropsContext,
+  NextApiRequest,
+  NextApiResponse,
+} from 'next'
+import type { ISitemapField } from '../interface'
+import { buildSitemapXml } from '../sitemap/buildSitemapXml'
+import { getServerSideSitemap } from './getServerSideSitemap'
+
+describe('Dynamic sitemap generation', () => {
+  test('Allows headers to be added', async () => {
+    const fields: ISitemapField[] = [
+      {
+        loc: 'https://example.com',
+        lastmod: undefined,
+      },
+      {
+        loc: 'https://example.com',
+        lastmod: 'some-value',
+      },
+    ]
+
+    const write = jest.fn()
+    const setHeader = jest.fn()
+    const ctx = ({
+      req: {} as NextApiRequest,
+      res: ({
+        write,
+        setHeader,
+        end: jest.fn(),
+      } as unknown) as NextApiResponse,
+    } as unknown) as GetServerSidePropsContext
+
+    const cacheHeader = 'max-age=60s'
+
+    const sitemapContent = buildSitemapXml(fields)
+
+    await getServerSideSitemap(ctx, fields, {
+      headers: {
+        'Cache-Control': cacheHeader,
+      },
+    })
+
+    expect(write).toHaveBeenCalledWith(sitemapContent)
+    expect(setHeader).toHaveBeenCalledWith('Content-Type', 'text/xml')
+    expect(setHeader).toHaveBeenCalledWith('Cache-Control', cacheHeader)
+  })
+})

--- a/packages/next-sitemap/src/dynamic-sitemap/getServerSideSitemap.ts
+++ b/packages/next-sitemap/src/dynamic-sitemap/getServerSideSitemap.ts
@@ -2,16 +2,27 @@
 import { ISitemapField } from '../interface'
 import { buildSitemapXml } from '../sitemap/buildSitemapXml'
 
+export type GetServerSideSitemapOptions = {
+  headers?: Record<string, string>
+}
+
 export const getServerSideSitemap = async (
   context: import('next').GetServerSidePropsContext,
-  fields: ISitemapField[]
+  fields: ISitemapField[],
+  opts?: GetServerSideSitemapOptions
 ) => {
   const sitemapContent = buildSitemapXml(fields)
 
   if (context && context.res) {
     const { res } = context
 
-    // Set header
+    if (opts?.headers) {
+      for (const [header, value] of Object.entries(opts.headers)) {
+        res.setHeader(header, value)
+      }
+    }
+
+    // Making sure Content-Type is always xml
     res.setHeader('Content-Type', 'text/xml')
 
     // Write the sitemap context to resonse

--- a/packages/next-sitemap/src/dynamic-sitemap/getServerSideSitemap.ts
+++ b/packages/next-sitemap/src/dynamic-sitemap/getServerSideSitemap.ts
@@ -3,7 +3,7 @@ import { ISitemapField } from '../interface'
 import { buildSitemapXml } from '../sitemap/buildSitemapXml'
 
 export type GetServerSideSitemapOptions = {
-  headers?: Record<string, string>
+  headers?: Record<string, string | number | readonly string[]>
 }
 
 export const getServerSideSitemap = async (


### PR DESCRIPTION
This allows returning a `Cache-Control` header that prevents crawlers from triggering expensive sitemap generation without resorting to solutions like the one in #106