### PR TITLE
Allow passing alternate urls when transforming

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ module.exports = {
   exclude: ['/protected-page', '/awesome/secret-page'],
   alternateRefs: [
     {
+      // final alternate url will be https://es.example.com/[path]
       href: 'https://es.example.com',
       hreflang: 'es',
     },
@@ -149,6 +150,14 @@ module.exports = {
   ],
   // Default transformation function
   transform: async (config, path) => {
+    let alternateUrls = []
+    if (path === '/I-am-english') {
+      alternateUrls = [
+        // final alternate url will be https://example.com/soy-espanol, not appending path
+        { href: 'https://example.com/soy-espanol', hreflang: 'es' },
+        { href: 'https://example.com/je-suis-francais', hreflang: 'fr' },
+      ]
+    }
     return {
       loc: path, // => this will be exported as http(s)://<config.siteUrl>/<path>
       changefreq: config.changefreq,

--- a/packages/next-sitemap/src/config/index.test.ts
+++ b/packages/next-sitemap/src/config/index.test.ts
@@ -89,6 +89,7 @@ describe('next-sitemap/config', () => {
       changefreq: 'weekly',
       priority: 0.6,
       alternateRefs: [],
+      alternateUrls: [],
     })
   })
 

--- a/packages/next-sitemap/src/config/index.ts
+++ b/packages/next-sitemap/src/config/index.ts
@@ -24,6 +24,7 @@ export const transformSitemap = async (
     priority: config?.priority,
     lastmod: config?.autoLastmod ? new Date().toISOString() : undefined,
     alternateRefs: config.alternateRefs ?? [],
+    alternateUrls: [],
   }
 }
 

--- a/packages/next-sitemap/src/interface.ts
+++ b/packages/next-sitemap/src/interface.ts
@@ -72,4 +72,5 @@ export type ISitemapField = {
   changefreq?: string
   priority?: string
   alternateRefs?: Array<AlternateRef>
+  alternateUrls?: Array<AlternateRef>
 }

--- a/packages/next-sitemap/src/sitemap/buildSitemapXml.ts
+++ b/packages/next-sitemap/src/sitemap/buildSitemapXml.ts
@@ -9,10 +9,12 @@ export const buildSitemapXml = (fields: ISitemapField[]): string => {
       // Iterate all object keys and key value pair to field-set
       for (const key of Object.keys(fieldData)) {
         if (fieldData[key]) {
-          if (key !== 'alternateRefs') {
-            field.push(`<${key}>${fieldData[key]}</${key}>`)
-          } else {
+          if (key === 'alternateRefs') {
             field.push(buildAlternateRefsXml(fieldData.alternateRefs))
+          } else if (key === 'alternateUrls') {
+            field.push(buildAlternateUrlsXml(fieldData.alternateUrls))
+          } else {
+            field.push(`<${key}>${fieldData[key]}</${key}>`)
           }
         }
       }
@@ -31,6 +33,16 @@ export const buildAlternateRefsXml = (
   return alternateRefs
     .map((alternateRef) => {
       return `<xhtml:link rel="alternate" hreflang="${alternateRef.hreflang}" href="${alternateRef.href}"/>`
+    })
+    .join('')
+}
+
+export const buildAlternateUrlsXml = (
+  alternateUrls: Array<AlternateRef> = []
+): string => {
+  return alternateUrls
+    .map((alternateUrl) => {
+      return `<xhtml:link rel="alternate" hreflang="${alternateUrl.hreflang}" href="${alternateUrl.href}"/>`
     })
     .join('')
 }

--- a/packages/next-sitemap/src/url/create-url-set/__tests__/create-url-set.test.ts
+++ b/packages/next-sitemap/src/url/create-url-set/__tests__/create-url-set.test.ts
@@ -1,4 +1,5 @@
 import { createUrlSet } from '..'
+import { transformSitemap } from '../../../config'
 import { sampleConfig } from '../../../fixtures/config'
 import { sampleManifest } from '../../../fixtures/manifest'
 
@@ -12,6 +13,7 @@ describe('createUrlSet', () => {
         priority: 0.7,
         loc: 'https://example.com',
         alternateRefs: [],
+        alternateUrls: [],
       },
       {
         changefreq: 'daily',
@@ -19,6 +21,7 @@ describe('createUrlSet', () => {
         priority: 0.7,
         loc: 'https://example.com/page-0',
         alternateRefs: [],
+        alternateUrls: [],
       },
       {
         changefreq: 'daily',
@@ -26,6 +29,7 @@ describe('createUrlSet', () => {
         priority: 0.7,
         loc: 'https://example.com/page-1',
         alternateRefs: [],
+        alternateUrls: [],
       },
       {
         changefreq: 'daily',
@@ -33,6 +37,7 @@ describe('createUrlSet', () => {
         priority: 0.7,
         loc: 'https://example.com/page-2',
         alternateRefs: [],
+        alternateUrls: [],
       },
       {
         changefreq: 'daily',
@@ -40,6 +45,7 @@ describe('createUrlSet', () => {
         priority: 0.7,
         loc: 'https://example.com/page-3',
         alternateRefs: [],
+        alternateUrls: [],
       },
     ])
   })
@@ -60,6 +66,7 @@ describe('createUrlSet', () => {
         priority: 0.7,
         loc: 'https://example.com/page-1',
         alternateRefs: [],
+        alternateUrls: [],
       },
       {
         changefreq: 'daily',
@@ -67,6 +74,7 @@ describe('createUrlSet', () => {
         priority: 0.7,
         loc: 'https://example.com/page-3',
         alternateRefs: [],
+        alternateUrls: [],
       },
     ])
   })
@@ -87,6 +95,7 @@ describe('createUrlSet', () => {
         priority: 0.7,
         loc: 'https://example.com',
         alternateRefs: [],
+        alternateUrls: [],
       },
     ])
   })
@@ -106,6 +115,7 @@ describe('createUrlSet', () => {
         priority: 0.7,
         loc: 'https://example.com',
         alternateRefs: [],
+        alternateUrls: [],
       },
       {
         changefreq: 'daily',
@@ -113,6 +123,7 @@ describe('createUrlSet', () => {
         priority: 0.7,
         loc: 'https://example.com/page-0',
         alternateRefs: [],
+        alternateUrls: [],
       },
       {
         changefreq: 'daily',
@@ -120,6 +131,7 @@ describe('createUrlSet', () => {
         priority: 0.7,
         loc: 'https://example.com/page-1',
         alternateRefs: [],
+        alternateUrls: [],
       },
       {
         changefreq: 'daily',
@@ -127,6 +139,7 @@ describe('createUrlSet', () => {
         priority: 0.7,
         loc: 'https://example.com/page-2',
         alternateRefs: [],
+        alternateUrls: [],
       },
       {
         changefreq: 'daily',
@@ -134,6 +147,7 @@ describe('createUrlSet', () => {
         priority: 0.7,
         loc: 'https://example.com/page-3',
         alternateRefs: [],
+        alternateUrls: [],
       },
     ])
   })
@@ -153,6 +167,7 @@ describe('createUrlSet', () => {
         priority: 0.7,
         loc: 'https://example.com/',
         alternateRefs: [],
+        alternateUrls: [],
       },
       {
         changefreq: 'daily',
@@ -160,6 +175,7 @@ describe('createUrlSet', () => {
         priority: 0.7,
         loc: 'https://example.com/page-0/',
         alternateRefs: [],
+        alternateUrls: [],
       },
       {
         changefreq: 'daily',
@@ -167,6 +183,7 @@ describe('createUrlSet', () => {
         priority: 0.7,
         loc: 'https://example.com/page-1/',
         alternateRefs: [],
+        alternateUrls: [],
       },
       {
         changefreq: 'daily',
@@ -174,6 +191,7 @@ describe('createUrlSet', () => {
         priority: 0.7,
         loc: 'https://example.com/page-2/',
         alternateRefs: [],
+        alternateUrls: [],
       },
       {
         changefreq: 'daily',
@@ -181,6 +199,7 @@ describe('createUrlSet', () => {
         priority: 0.7,
         loc: 'https://example.com/page-3/',
         alternateRefs: [],
+        alternateUrls: [],
       },
     ])
   })
@@ -209,11 +228,13 @@ describe('createUrlSet', () => {
         changefreq: 'yearly',
         loc: 'https://example.com/',
         alternateRefs: [],
+        alternateUrls: [],
       },
       {
         changefreq: 'yearly',
         loc: 'https://example.com/page-2/',
         alternateRefs: [],
+        alternateUrls: [],
       },
     ])
   })
@@ -241,6 +262,7 @@ describe('createUrlSet', () => {
           { href: 'https://en.example.com', hreflang: 'en' },
           { href: 'https://fr.example.com', hreflang: 'fr' },
         ],
+        alternateUrls: [],
       },
       {
         changefreq: 'daily',
@@ -251,6 +273,7 @@ describe('createUrlSet', () => {
           { href: 'https://en.example.com/page-0', hreflang: 'en' },
           { href: 'https://fr.example.com/page-0', hreflang: 'fr' },
         ],
+        alternateUrls: [],
       },
       {
         changefreq: 'daily',
@@ -261,6 +284,7 @@ describe('createUrlSet', () => {
           { href: 'https://en.example.com/page-1', hreflang: 'en' },
           { href: 'https://fr.example.com/page-1', hreflang: 'fr' },
         ],
+        alternateUrls: [],
       },
       {
         changefreq: 'daily',
@@ -271,6 +295,7 @@ describe('createUrlSet', () => {
           { href: 'https://en.example.com/page-2', hreflang: 'en' },
           { href: 'https://fr.example.com/page-2', hreflang: 'fr' },
         ],
+        alternateUrls: [],
       },
       {
         changefreq: 'daily',
@@ -281,6 +306,75 @@ describe('createUrlSet', () => {
           { href: 'https://en.example.com/page-3', hreflang: 'en' },
           { href: 'https://fr.example.com/page-3', hreflang: 'fr' },
         ],
+        alternateUrls: [],
+      },
+    ])
+  })
+
+  test('with alternateUrls', async () => {
+    const urlset = await createUrlSet(
+      {
+        ...sampleConfig,
+        siteUrl: 'https://example.com',
+        transform: async (config, url) => {
+          if (url.endsWith('page-0')) {
+            return {
+              ...(await transformSitemap(config, url)),
+              alternateUrls: [
+                { href: 'https://example.com/hola', hreflang: 'es' },
+                { href: 'https://example.com/bonjour', hreflang: 'fr' },
+              ],
+            }
+          }
+          return transformSitemap(config, url)
+        },
+      },
+      sampleManifest
+    )
+
+    expect(urlset).toStrictEqual([
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        loc: 'https://example.com',
+        alternateRefs: [],
+        alternateUrls: [],
+      },
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        loc: 'https://example.com/page-0',
+        alternateRefs: [],
+        alternateUrls: [
+          { href: 'https://example.com/hola', hreflang: 'es' },
+          { href: 'https://example.com/bonjour', hreflang: 'fr' },
+        ],
+      },
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        loc: 'https://example.com/page-1',
+        alternateRefs: [],
+        alternateUrls: [],
+      },
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        loc: 'https://example.com/page-2',
+        alternateRefs: [],
+        alternateUrls: [],
+      },
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        loc: 'https://example.com/page-3',
+        alternateRefs: [],
+        alternateUrls: [],
       },
     ])
   })

--- a/packages/next-sitemap/src/url/create-url-set/index.ts
+++ b/packages/next-sitemap/src/url/create-url-set/index.ts
@@ -58,6 +58,10 @@ export const createUrlSet = async (
         href: absoluteUrl(alternateRef.href, x.loc, config.trailingSlash),
         hreflang: alternateRef.hreflang,
       })),
+      alternateUrls: (x.alternateUrls ?? []).map((alternateUrl) => ({
+        href: absoluteUrl(alternateUrl.href, '', config.trailingSlash),
+        hreflang: alternateUrl.hreflang,
+      })),
     }))
 
   return sitemapFields


### PR DESCRIPTION
`alternateRefs` works great when using just a different subdomain for alternate pages.

But sometimes we use the path for the language, and have translated paths, therefore the following are alternate pages : 

`https://example.com/hello`
`https://example.com/fr/bonjour`
`https://example.com/es/hola`

We need to be able to set the full alternate url when transforming the sitemap entry.