### PR TITLE
Add additionalPaths parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,7 @@ Above is the minimal configuration to split a large sitemap. When the number of 
 | sourceDir (optional)                           | next.js build directory. Default `.next`                                                                                                                                                                                                                                                                                                                          | string         |
 | outDir (optional)                              | All the generated files will be exported to this directory. Default `public`                                                                                                                                                                                                                                                                                      | string         |
 | transform (optional)                           | A transformation function, which runs **for each** `relative-path` in the sitemap. Returning `null` value from the transformation function will result in the exclusion of that specific `path` from the generated sitemap list.                                                                                                                                  | async function |
-
-| additionalPaths (optional) | A function that returns a list of additional paths to be added to the general list. | async function |
+| additionalPaths (optional)                     | A function that returns a list of additional paths to be added to the general list.                                                                                                                                                                                                                                                                               | async function |
 
 ## Custom transformation function
 

--- a/packages/next-sitemap/src/interface.ts
+++ b/packages/next-sitemap/src/interface.ts
@@ -1,3 +1,6 @@
+type MaybeUndefined<T> = T | undefined
+type MaybePromise<T> = T | Promise<T>
+
 export interface IRobotPolicy {
   userAgent: string
   disallow?: string | string[]
@@ -22,9 +25,21 @@ export interface IConfig {
   autoLastmod?: boolean
   exclude?: string[]
   alternateRefs?: Array<AlternateRef>
-  transform?: (config: IConfig, url: string) => Promise<ISitemapField>
+  transform?: (
+    config: IConfig,
+    url: string
+  ) => MaybePromise<MaybeUndefined<ISitemapField>>
+  additionalPaths?: (
+    config: AdditionalPathsConfig
+  ) => MaybePromise<MaybeUndefined<ISitemapField>[]>
   trailingSlash?: boolean
 }
+
+export type AdditionalPathsConfig = Readonly<
+  IConfig & {
+    transform: NonNullable<IConfig['transform']>
+  }
+>
 
 export interface IBuildManifest {
   pages: {
@@ -70,6 +85,6 @@ export type ISitemapField = {
   loc: string
   lastmod?: string
   changefreq?: string
-  priority?: string
+  priority?: number
   alternateRefs?: Array<AlternateRef>
 }

--- a/packages/next-sitemap/src/url/create-url-set/__tests__/create-url-set.test.ts
+++ b/packages/next-sitemap/src/url/create-url-set/__tests__/create-url-set.test.ts
@@ -1,6 +1,8 @@
 import { createUrlSet } from '..'
+import { transformSitemap } from '../../../config'
 import { sampleConfig } from '../../../fixtures/config'
 import { sampleManifest } from '../../../fixtures/manifest'
+import { IConfig } from '../../../interface'
 
 describe('createUrlSet', () => {
   test('without exclusion', async () => {
@@ -281,6 +283,90 @@ describe('createUrlSet', () => {
           { href: 'https://en.example.com/page-3', hreflang: 'en' },
           { href: 'https://fr.example.com/page-3', hreflang: 'fr' },
         ],
+      },
+    ])
+  })
+
+  test('with additionalPaths', async () => {
+    const transform: IConfig['transform'] = async (config, url) => {
+      if (['/', '/page-0', '/page-1'].includes(url)) {
+        return
+      }
+
+      if (url === '/additional-page-3') {
+        return {
+          loc: url,
+          changefreq: 'yearly',
+          priority: 0.8,
+        }
+      }
+
+      return transformSitemap(config, url)
+    }
+
+    const mockTransform = jest.fn(transform)
+
+    const config: IConfig = {
+      ...sampleConfig,
+      siteUrl: 'https://example.com/',
+      transform: mockTransform,
+      additionalPaths: async (config) => [
+        { loc: '/page-1', priority: 1, changefreq: 'yearly' },
+        { loc: '/page-3', priority: 0.9, changefreq: 'yearly' },
+        { loc: '/additional-page-1' },
+        { loc: '/additional-page-2', priority: 1, changefreq: 'yearly' },
+        await config.transform(config, '/additional-page-3'),
+      ],
+    }
+
+    const urlset = await createUrlSet(config, sampleManifest)
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    expect(mockTransform.mock.calls.map(([_, url]) => url)).toEqual([
+      '/',
+      '/page-0',
+      '/page-1',
+      '/page-2',
+      '/page-3',
+      '/additional-page-3',
+    ])
+
+    expect(urlset).toStrictEqual([
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        loc: 'https://example.com/page-2',
+        alternateRefs: [],
+      },
+      {
+        changefreq: 'yearly',
+        lastmod: expect.any(String),
+        priority: 0.9,
+        loc: 'https://example.com/page-3',
+        alternateRefs: [],
+      },
+      {
+        changefreq: 'yearly',
+        priority: 1,
+        loc: 'https://example.com/page-1',
+        alternateRefs: [],
+      },
+      {
+        loc: 'https://example.com/additional-page-1',
+        alternateRefs: [],
+      },
+      {
+        changefreq: 'yearly',
+        priority: 1,
+        loc: 'https://example.com/additional-page-2',
+        alternateRefs: [],
+      },
+      {
+        changefreq: 'yearly',
+        priority: 0.8,
+        loc: 'https://example.com/additional-page-3',
+        alternateRefs: [],
       },
     ])
   })

--- a/packages/next-sitemap/src/url/create-url-set/index.ts
+++ b/packages/next-sitemap/src/url/create-url-set/index.ts
@@ -2,6 +2,7 @@
 import { IConfig, INextManifest, ISitemapField } from '../../interface'
 import { isNextInternalUrl, generateUrl } from '../util'
 import { removeIfMatchPattern } from '../../array'
+import { transformSitemap } from '../../config'
 
 export const absoluteUrl = (
   siteUrl: string,
@@ -42,23 +43,55 @@ export const createUrlSet = async (
   urlSet = [...new Set(urlSet)]
 
   // Create sitemap fields based on transformation
-  let sitemapFields: ISitemapField[] = [] // transform using relative urls
+  const sitemapFields: ISitemapField[] = [] // transform using relative urls
+
+  // Create a map of fields by loc to quickly find collisions
+  const mapFieldsByLoc: { [key in string]: ISitemapField } = {}
 
   for (const url of urlSet) {
     const sitemapField = await config.transform!(config, url)
+
+    if (!sitemapField?.loc) continue
+
     sitemapFields.push(sitemapField)
+
+    // Add link on field to map by loc
+    if (config.additionalPaths) {
+      mapFieldsByLoc[sitemapField.loc] = sitemapField
+    }
   }
 
-  sitemapFields = sitemapFields
-    .filter((x) => Boolean(x) && Boolean(x.loc)) // remove null values
-    .map((x) => ({
-      ...x,
-      loc: absoluteUrl(config.siteUrl, x.loc, config.trailingSlash), // create absolute urls based on sitemap fields
-      alternateRefs: (x.alternateRefs ?? []).map((alternateRef) => ({
-        href: absoluteUrl(alternateRef.href, x.loc, config.trailingSlash),
-        hreflang: alternateRef.hreflang,
-      })),
-    }))
+  if (config.additionalPaths) {
+    const additions =
+      (await config.additionalPaths({
+        ...config,
+        transform: config.transform ?? transformSitemap,
+      })) ?? []
 
-  return sitemapFields
+    for (const field of additions) {
+      if (!field?.loc) continue
+
+      const collision = mapFieldsByLoc[field.loc]
+
+      // Update first entry
+      if (collision) {
+        // Mutate common entry between sitemapFields and mapFieldsByLoc (spread operator don't work)
+        Object.entries(field).forEach(
+          ([key, value]) => (collision[key] = value)
+        )
+        continue
+      }
+
+      sitemapFields.push(field)
+    }
+  }
+
+  return sitemapFields.map((x) => ({
+    ...x,
+    loc: absoluteUrl(config.siteUrl, x.loc, config.trailingSlash), // create absolute urls based on sitemap fields
+    alternateRefs: (x.alternateRefs ?? []).map((alternateRef) => ({
+      href: absoluteUrl(alternateRef.href, x.loc, config.trailingSlash),
+      hreflang: alternateRef.hreflang,
+    })),
+  }))
 }


### PR DESCRIPTION
I have 150k+ pages on my project, and I have to use fallback: true to avoid rendering them all. I can not use `additionalSitemaps` because I do not know the exact number of pages to divide them into different sitemap.

I suggest you consider my solution