### PR TITLE
fix(types): sync config interface with docs

### DIFF
--- a/packages/next-sitemap/src/interface.ts
+++ b/packages/next-sitemap/src/interface.ts
@@ -11,13 +11,13 @@ export interface IRobotsTxt {
 
 export interface IConfig {
   siteUrl: string
-  changefreq: string
-  priority: any
+  changefreq?: string
+  priority?: number
   sitemapBaseFileName?: string
   sourceDir?: string
   outDir?: string
   sitemapSize?: number
-  generateRobotsTxt: boolean
+  generateRobotsTxt?: boolean
   robotsTxtOptions?: IRobotsTxt
   autoLastmod?: boolean
   exclude?: string[]


### PR DESCRIPTION
This PR syncs the config interface with the documented spec on the readme (<https://github.com/iamvishnusankar/next-sitemap#configuration-options>). Notable changes are:

- `changefreq` is set to optional
- `priority` is set to optional and uses `number` instead of `any`
- `generateRobotsTxt` is to optional

If I missed anything that require these options to be required, maintainers may close this PR.