### PR TITLE
Replace default locale before processing excludes

### DIFF
--- a/packages/next-sitemap/src/url/create-url-set/__tests__/create-url-set.test.ts
+++ b/packages/next-sitemap/src/url/create-url-set/__tests__/create-url-set.test.ts
@@ -73,6 +73,33 @@ describe('createUrlSet', () => {
     ])
   })
 
+  test('with i18n exclusion', async () => {
+    const urlset = await createUrlSet(
+      {
+        ...sampleConfig,
+        exclude: ['/', '/page-0', '/page-2', '/about', '/fr*'],
+      },
+      sampleI18nManifest
+    )
+
+    expect(urlset).toStrictEqual([
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        loc: 'https://example.com/page-1',
+        alternateRefs: [],
+      },
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        loc: 'https://example.com/page-3',
+        alternateRefs: [],
+      },
+    ])
+  })
+
   test('with wildcard exclusion', async () => {
     const urlset = await createUrlSet(
       {

--- a/packages/next-sitemap/src/url/create-url-set/index.ts
+++ b/packages/next-sitemap/src/url/create-url-set/index.ts
@@ -48,15 +48,10 @@ export const createUrlSet = async (
 ): Promise<ISitemapField[]> => {
   const i18n = manifest.routes?.i18n
 
-  let allKeys = [
+  const allKeys = [
     ...Object.keys(manifest.build.pages),
     ...(manifest.preRender ? Object.keys(manifest.preRender.routes) : []),
   ]
-
-  // Remove the urls based on config.exclude array
-  if (config.exclude && config.exclude.length > 0) {
-    allKeys = removeIfMatchPattern(allKeys, config.exclude)
-  }
 
   // Filter out next.js internal urls and generate urls based on sitemap
   let urlSet = allKeys.filter((x) => !isNextInternalUrl(x))
@@ -66,6 +61,11 @@ export const createUrlSet = async (
     const { defaultLocale } = i18n
     const replaceDefaultLocale = createDefaultLocaleReplace(defaultLocale)
     urlSet = urlSet.map(replaceDefaultLocale)
+  }
+
+  // Remove the urls based on config.exclude array
+  if (config.exclude && config.exclude.length > 0) {
+    urlSet = removeIfMatchPattern(urlSet, config.exclude)
   }
 
   urlSet = [...new Set(urlSet)]


### PR DESCRIPTION
Hi @iamvishnusankar 

Thanks for merging the support for i18n and also ensuring next-sitemap works with Next 12, this is much appreciated.

While upgrading the package I noticed some of the excludes are not respected. The reason for this is that the excludes are processed before removing the default locale, this means the exclude will apply to the default path, but once the default locale is removed (which happens after the excludes are processed) the same excluded path may return.

Example:

Before default locale is removed, we may start with this list

Given default locale of /en, we want to exclude /about

- /about
- /en/about
- /company

If we exclude the /about path we get

- /en/about
- /company

And then we remove the default locale

- /about
- /company

We end up with the path we wanted to exclude due to the default locale replacement happening after the excludes.

I changed the order in which the operations happen to first normalize the set as much as possible (removing internal next routes and default locale) and only then apply the excludes.

I also added tests for this.

Thank you

