### PR TITLE
Ignore _middleware routes

### DIFF
--- a/packages/next-sitemap/src/url/util/index.test.ts
+++ b/packages/next-sitemap/src/url/util/index.test.ts
@@ -45,6 +45,7 @@ describe('next-sitemap', () => {
     expect(isNextInternalUrl('/_middleware')).toBeTruthy()
     expect(isNextInternalUrl('/about/_middleware')).toBeTruthy()
     expect(isNextInternalUrl('/some_url/about/_middleware')).toBeTruthy()
+    expect(isNextInternalUrl('/projects/[id]/_middleware')).toBeTruthy()
   })
 
   test('isNextInternalUrl: url params', () => {

--- a/packages/next-sitemap/src/url/util/index.test.ts
+++ b/packages/next-sitemap/src/url/util/index.test.ts
@@ -42,6 +42,9 @@ describe('next-sitemap', () => {
     expect(isNextInternalUrl('/_app')).toBeTruthy()
     expect(isNextInternalUrl('/404')).toBeTruthy()
     expect(isNextInternalUrl('/_random')).toBeTruthy()
+    expect(isNextInternalUrl('/_middleware')).toBeTruthy()
+    expect(isNextInternalUrl('/about/_middleware')).toBeTruthy()
+    expect(isNextInternalUrl('/some_url/about/_middleware')).toBeTruthy()
   })
 
   test('isNextInternalUrl: url params', () => {

--- a/packages/next-sitemap/src/url/util/index.ts
+++ b/packages/next-sitemap/src/url/util/index.ts
@@ -18,7 +18,7 @@ export const generateUrl = (baseUrl: string, slug: string): string => {
  * @param path path check
  */
 export const isNextInternalUrl = (path: string): boolean => {
-  return new RegExp(/[^\/]*^.[_]|^\/404$|(?:\[)/g).test(path)
+  return new RegExp(/[^\/]*^.[_]|^\/404$|\/_middleware$|(?:\[)/g).test(path)
 }
 
 /**


### PR DESCRIPTION
Next.js 12 introduced [Middlewares](https://nextjs.org/docs/middleware), this consists in `_middleware` files existing in the pages folder. Currently next-sitemap does not know it should ignore these files because they don't necessarily live at the root folder like other next.js files, so this change updates the `isNextInternalUrl` to consider paths with `_middleware` at the end of the path as internal urls.