### PR TITLE
Add option for alternateRefs to be marked as absolute

### DIFF
--- a/packages/next-sitemap/src/interface.ts
+++ b/packages/next-sitemap/src/interface.ts
@@ -98,6 +98,7 @@ export interface IRuntimePaths {
 export type AlternateRef = {
   href: string
   hreflang: string
+  hrefIsAbsolute?: boolean
 }
 
 export type ISitemapField = {

--- a/packages/next-sitemap/src/url/create-url-set/__tests__/create-url-set.test.ts
+++ b/packages/next-sitemap/src/url/create-url-set/__tests__/create-url-set.test.ts
@@ -2,7 +2,7 @@ import { createUrlSet } from '..'
 import { transformSitemap } from '../../../config'
 import { sampleConfig } from '../../../fixtures/config'
 import { sampleManifest, sampleI18nManifest } from '../../../fixtures/manifest'
-import { IConfig } from '../../../interface'
+import { IConfig, ISitemapField } from '../../../interface'
 
 describe('createUrlSet', () => {
   test('without exclusion', async () => {
@@ -309,6 +309,120 @@ describe('createUrlSet', () => {
         alternateRefs: [
           { href: 'https://en.example.com/page-3', hreflang: 'en' },
           { href: 'https://fr.example.com/page-3', hreflang: 'fr' },
+        ],
+      },
+    ])
+  })
+
+  test('with absolute alternateRefs', async () => {
+    const urlset = await createUrlSet(
+      {
+        ...sampleConfig,
+        siteUrl: 'https://example.com/',
+        alternateRefs: [
+          { href: 'https://example.com/en', hreflang: 'en' },
+          { href: 'https://example.com/fr', hreflang: 'fr' },
+          { href: 'https://example.com/it', hreflang: 'it' },
+          { href: 'https://example.com/de', hreflang: 'de' },
+        ],
+        transform: (config, url) => {
+          const sitemapField = {
+            loc: url,
+            changefreq: config.changefreq,
+            priority: config.priority,
+            alternateRefs: config.alternateRefs,
+            lastmod: new Date().toISOString(),
+          } as ISitemapField
+          if (url.startsWith('/page')) {
+            sitemapField.alternateRefs = [
+              {
+                href: 'https://example.com/en',
+                hreflang: 'en',
+              },
+              {
+                href: 'https://example.com/fr',
+                hreflang: 'fr',
+              },
+              {
+                href: `https://example.com/it${url.replace(
+                  '/page',
+                  '/pagina'
+                )}`,
+                hreflang: 'it',
+                hrefIsAbsolute: true,
+              },
+              {
+                href: `https://example.com/de${url.replace('/page', '/seite')}`,
+                hreflang: 'de',
+                hrefIsAbsolute: true,
+              },
+            ]
+          }
+          return sitemapField
+        },
+      },
+      sampleManifest
+    )
+
+    expect(urlset).toStrictEqual([
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        loc: 'https://example.com',
+        alternateRefs: [
+          { href: 'https://example.com/en', hreflang: 'en' },
+          { href: 'https://example.com/fr', hreflang: 'fr' },
+          { href: 'https://example.com/it', hreflang: 'it' },
+          { href: 'https://example.com/de', hreflang: 'de' },
+        ],
+      },
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        loc: 'https://example.com/page-0',
+        alternateRefs: [
+          { href: 'https://example.com/en/page-0', hreflang: 'en' },
+          { href: 'https://example.com/fr/page-0', hreflang: 'fr' },
+          { href: 'https://example.com/it/pagina-0', hreflang: 'it' },
+          { href: 'https://example.com/de/seite-0', hreflang: 'de' },
+        ],
+      },
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        loc: 'https://example.com/page-1',
+        alternateRefs: [
+          { href: 'https://example.com/en/page-1', hreflang: 'en' },
+          { href: 'https://example.com/fr/page-1', hreflang: 'fr' },
+          { href: 'https://example.com/it/pagina-1', hreflang: 'it' },
+          { href: 'https://example.com/de/seite-1', hreflang: 'de' },
+        ],
+      },
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        loc: 'https://example.com/page-2',
+        alternateRefs: [
+          { href: 'https://example.com/en/page-2', hreflang: 'en' },
+          { href: 'https://example.com/fr/page-2', hreflang: 'fr' },
+          { href: 'https://example.com/it/pagina-2', hreflang: 'it' },
+          { href: 'https://example.com/de/seite-2', hreflang: 'de' },
+        ],
+      },
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        loc: 'https://example.com/page-3',
+        alternateRefs: [
+          { href: 'https://example.com/en/page-3', hreflang: 'en' },
+          { href: 'https://example.com/fr/page-3', hreflang: 'fr' },
+          { href: 'https://example.com/it/pagina-3', hreflang: 'it' },
+          { href: 'https://example.com/de/seite-3', hreflang: 'de' },
         ],
       },
     ])

--- a/packages/next-sitemap/src/url/create-url-set/index.ts
+++ b/packages/next-sitemap/src/url/create-url-set/index.ts
@@ -118,7 +118,9 @@ export const createUrlSet = async (
     ...x,
     loc: absoluteUrl(config.siteUrl, x.loc, config.trailingSlash), // create absolute urls based on sitemap fields
     alternateRefs: (x.alternateRefs ?? []).map((alternateRef) => ({
-      href: absoluteUrl(alternateRef.href, x.loc, config.trailingSlash),
+      href: alternateRef.hrefIsAbsolute
+        ? alternateRef.href
+        : absoluteUrl(alternateRef.href, x.loc, config.trailingSlash),
       hreflang: alternateRef.hreflang,
     })),
   }))


### PR DESCRIPTION
It seems that v2 of this project is well on its way, but I'm hoping this PR will still be accepted v1.9.x or incorporated into the upcoming v2 instead _(assuming it's still relevant/required as I'm not sure what other changes you have in store)_.

This is a great project and thank you for creating & maintaining it @iamvishnusankar!

This PR aims to add an override option for `AlternateRef` that opts an alternate ref out of the absolute url construction at the end of `createUrlSet`. The option is currently named `hrefIsAbsolute` but any suggestions for better naming are very welcome.

The use case is that for a few reasons our i18n implementation alters the path of a URL to reflect the user's language beyond the usual `fr.example.com` or `example.com/fr` setup. Paths such as `example.com/news/summer-2021` are converted to `example.com/nl/nieuws/zomer-2021` or `example.com/it/notizie/estate-2021`.

These conversions follow strict recipes so we have been using the custom transform function to alter the `alternateRefs` for relevant URLs but have noticed that the current version appends the original `loc` onto the end of any path we convert ([see here](https://github.com/iamvishnusankar/next-sitemap/blob/c5f370151783ad90853798e8d7a02605b707bb7d/packages/next-sitemap/src/url/create-url-set/index.ts#L121)). So we get `example.com/it/notizie/estate-2021/news/summer-2021` instead.

This PR adds an optional `hrefIsAbsolute: boolean` property to AlternateRef objects, which can be set in the transform function which is then observed by the `createUrlSet` return to avoid running that specific alternateRef's `href` through the `absoluteUrl` constructor.

I haven't altered the README to cover this property as it is likely an 'Advanced' feature of sorts and I also couldn't work out where would be best to add it? Seems the README simply refers to the `AlternateRef` type by way of detailing the structure of `alternateRefs`. But please let me know if an alteration would be required for the PR to be accepted.