### PR TITLE
Added Clean-Param field to robots.txt policies

### DIFF
--- a/packages/next-sitemap/src/interface.ts
+++ b/packages/next-sitemap/src/interface.ts
@@ -33,6 +33,11 @@ export interface IRobotPolicy {
    * Crawl delay
    */
   crawlDelay?: number
+
+  /**
+   * Crawl delay
+   */
+  cleanParam?: string | string[]
 }
 
 export interface IRobotsTxt {

--- a/packages/next-sitemap/src/robots-txt/generate/index.ts
+++ b/packages/next-sitemap/src/robots-txt/generate/index.ts
@@ -27,6 +27,10 @@ export const generateRobotsTxt = (config: IConfig): string | null => {
       content += `Crawl-delay: ${x.crawlDelay}\n`
     }
 
+    if (x.cleanParam) {
+      content += `${addPolicies('Clean-param', x.cleanParam as string[])}`
+    }
+
     content += '\n'
   })
 

--- a/packages/next-sitemap/src/robots-txt/policy/index.ts
+++ b/packages/next-sitemap/src/robots-txt/policy/index.ts
@@ -7,6 +7,7 @@ export const normalizePolicy = (policies: IRobotPolicy[]): IRobotPolicy[] => {
     ...x,
     allow: toArray(x.allow!),
     disallow: toArray(x.disallow!),
+    cleanParam: toArray(x.cleanParam!)
   }))
 }
 


### PR DESCRIPTION
For user-agent: yandex, it is recommended to add the Clean-param parameter, in the previous version it was impossible to do this. Thanks for the great library)