### PR TITLE
Fix incorrect default export syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
 }
 
 // Default export to prevent next.js errors
-export default Sitemap = () => {}
+export default function Sitemap() {}
 ```
 
 Now, `next.js` is serving the dynamic sitemap from `http://localhost:3000/server-sitemap.xml`.


### PR DESCRIPTION
The readme references exporting a default `Sitemap` function, which doesn't yet exist. This PR addresses the issue by using a traditional function expression opposed to an arrow function expression.