### PR TITLE
[Fix] Consider /500 as a Next.js internal URL and ignore it

### DIFF
--- a/packages/next-sitemap/src/url/util/index.test.ts
+++ b/packages/next-sitemap/src/url/util/index.test.ts
@@ -41,6 +41,7 @@ describe('next-sitemap', () => {
   test('isNextInternalUrl', () => {
     expect(isNextInternalUrl('/_app')).toBeTruthy()
     expect(isNextInternalUrl('/404')).toBeTruthy()
+    expect(isNextInternalUrl('/500')).toBeTruthy()
     expect(isNextInternalUrl('/_random')).toBeTruthy()
     expect(isNextInternalUrl('/_middleware')).toBeTruthy()
     expect(isNextInternalUrl('/about/_middleware')).toBeTruthy()
@@ -59,6 +60,7 @@ describe('next-sitemap', () => {
 
     expect(isNextInternalUrl('/some_url')).toBeFalsy()
     expect(isNextInternalUrl('/some-404')).toBeFalsy()
+    expect(isNextInternalUrl('/some-500')).toBeFalsy()
   })
 
   test('createDefaultLocaleReplace: replaces default locale within path`', () => {

--- a/packages/next-sitemap/src/url/util/index.ts
+++ b/packages/next-sitemap/src/url/util/index.ts
@@ -18,7 +18,7 @@ export const generateUrl = (baseUrl: string, slug: string): string => {
  * @param path path check
  */
 export const isNextInternalUrl = (path: string): boolean => {
-  return new RegExp(/[^\/]*^.[_]|^\/404$|\/_middleware$|(?:\[)/g).test(path)
+  return new RegExp(/[^\/]*^.[_]|^\/(404|500)$|\/_middleware$|(?:\[)/g).test(path)
 }
 
 /**


### PR DESCRIPTION
The optional [custom 500 error page](https://nextjs.org/docs/advanced-features/custom-error-page) is appearing on the generated sitemaps; we probably want to ignore it as well. :) 