### PR TITLE
make priority and changefreq params optional

### DIFF
--- a/packages/next-sitemap/src/interface.ts
+++ b/packages/next-sitemap/src/interface.ts
@@ -78,13 +78,13 @@ export interface IConfig {
    * Change frequency.
    * @default 'daily'
    */
-  changefreq: Changefreq
+  changefreq?: Changefreq
 
   /**
    * Priority
    * @default 0.7
    */
-  priority: any
+  priority?: any
 
   /**
    * The name of the generated sitemap file before the file extension.


### PR DESCRIPTION
According to the docs, `changefreq` and `priority` are optional params.
Updated the typescript typings to match documentation and behavior.