### PR TITLE
Fix "Content-Type" "application/xml"

### DIFF
--- a/packages/next-sitemap/src/ssr/response.ts
+++ b/packages/next-sitemap/src/ssr/response.ts
@@ -14,7 +14,7 @@ export const withXMLResponse = (
     const { res } = ctx
 
     // Set header
-    res.setHeader('Content-Type', 'text/xml')
+    res.setHeader('Content-Type', 'application/xml')
 
     // Write the sitemap context to resonse
     res.write(content)


### PR DESCRIPTION
Fix content type for Google and to match the docs https://github.com/iamvishnusankar/next-sitemap#generating-dynamicserver-side-sitemaps

Related https://github.com/iamvishnusankar/next-sitemap/issues/387