### PR TITLE
fix: check if URL with replaced defaultLocale in notFoundRoutes

### DIFF
--- a/packages/next-sitemap/src/__fixtures__/manifest.ts
+++ b/packages/next-sitemap/src/__fixtures__/manifest.ts
@@ -72,6 +72,7 @@ export const sampleNotFoundRoutesBuildManifest: IBuildManifest = {
   pages: {
     '/': [],
     '/about': [],
+    '/only-nl': [],
     '/[dynamic]': [],
     '/_app': [],
     '/_error': [],
@@ -87,6 +88,10 @@ export const sampleNotFoundRoutesPreRenderManifest: IPreRenderManifest = {
     '/fr/about': {},
     '/nl-NL/about': {},
 
+    '/en-US/only-nl': {},
+    '/fr/only-nl': {},
+    '/nl-NL/only-nl': {},
+
     '/en-US/page-0': {},
     '/fr/page-0': {},
     '/nl-NL/page-0': {},
@@ -98,6 +103,8 @@ export const sampleNotFoundRoutesPreRenderManifest: IPreRenderManifest = {
   notFoundRoutes: [
     '/fr',
     '/nl-NL/about',
+    '/en-US/only-nl',
+    '/fr/only-nl',
     '/nl-NL/page-0',
     '/fr/page-1',
     '/nl-NL/page-1',

--- a/packages/next-sitemap/src/builders/__tests__/url-set-builder/create-url-set.test.ts
+++ b/packages/next-sitemap/src/builders/__tests__/url-set-builder/create-url-set.test.ts
@@ -633,6 +633,15 @@ describe('UrlSetBuilder', () => {
         alternateRefs: [],
         trailingSlash: false,
       },
+      // only localized page
+      {
+        changefreq: 'daily',
+        lastmod: expect.any(String),
+        priority: 0.7,
+        loc: 'https://example.com/nl-NL/only-nl',
+        alternateRefs: [],
+        trailingSlash: false,
+      },
       // page-0
       {
         changefreq: 'daily',

--- a/packages/next-sitemap/src/builders/url-set-builder.ts
+++ b/packages/next-sitemap/src/builders/url-set-builder.ts
@@ -79,8 +79,9 @@ export class UrlSetBuilder {
     let urlSet = allKeys.filter((x) => !isNextInternalUrl(x))
 
     // Remove default locale if i18n is enabled
+    let defaultLocale
     if (i18n) {
-      const { defaultLocale } = i18n
+      defaultLocale = i18n.defaultLocale
       const replaceDefaultLocale = createDefaultLocaleReplace(defaultLocale)
       urlSet = urlSet.map(replaceDefaultLocale)
     }
@@ -95,7 +96,12 @@ export class UrlSetBuilder {
     // Remove routes which don't exist
     const notFoundRoutes = (this.manifest?.preRender?.notFoundRoutes ??
       []) as string[]
-    urlSet = urlSet.filter((url) => !notFoundRoutes.includes(url))
+    urlSet = urlSet.filter((url) => {
+      return (
+        !notFoundRoutes.includes(url) &&
+        !notFoundRoutes.includes(`/${defaultLocale}${url}`)
+      )
+    })
 
     // Create sitemap fields based on transformation
     const sitemapFields: ISitemapField[] = [] // transform using relative urls


### PR DESCRIPTION
## Issue
Suppose there is a route `/only-nl`, that only exists in a particular locale, `nl-NL`. Currently, when generating the sitemap, we will see both the following `loc` in the sitemap:

```
/only-nl
/nl-NL/only-nl
```

This^ is wrong, since the route only exists in the `nl-NL` locale. Here is the expected output:

```diff
- /only-nl 
/nl-NL/only-nl
```

## Why
We currently [replace the `defaultLocale` (when i18n is enabled)](https://github.com/iamvishnusankar/next-sitemap/blob/master/packages/next-sitemap/src/builders/url-set-builder.ts#L84) in the `urlSet` (with the help of a [regex](https://github.com/iamvishnusankar/next-sitemap/blob/master/packages/next-sitemap/src/utils/url.ts#L42)), but URLs in `notFoundRoutes` are not replaced.

This would cause "notFound" routes on the `defaultLocale` (like `/only-NL`) to be missed when filtering.

## What I've done
- Add an additional check if url with `defaultLocale` replaced is included in `notFoundRoutes`
- Update related fixtures and test

Please let me know if there's anything else you'd like me to add here, and feedback if it can be handled in a better way.

Thanks!