### PR TITLE
Fix usage example in "Google News, image and video sitemap"

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ const config = {
       changefreq: config.changefreq,
       priority: config.priority,
       lastmod: config.autoLastmod ? new Date().toISOString() : undefined,
-      images: [{ loc: 'https://example.com/image.jpg' }],
+      images: [{ loc: { href: 'https://example.com/image.jpg' } }],
       news: {
         title: 'Article 1',
         publicationName: 'Google Scholar',


### PR DESCRIPTION
In "Google News, image and video sitemap" the following line will produce `<image:loc>undefined</image:loc>`:

```javascript
      images: [{ loc: 'https://example.com/image.jpg' }],
```

This needs to be changed to:

```javascript
      images: [{ loc: { href: 'https://example.com/image.jpg' } }],
```