### PR TITLE
Fix README for images

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ const config = {
       changefreq: config.changefreq,
       priority: config.priority,
       lastmod: config.autoLastmod ? new Date().toISOString() : undefined,
-      images: [{ loc: 'https://example.com/image.jpg' }],
+      images: [{ loc: new URL('https://example.com/image.jpg') }],
       news: {
         title: 'Article 1',
         publicationName: 'Google Scholar',


### PR DESCRIPTION
`images.loc` is `URL` type. If we use `string` type to set `images.loc`, it would get `undefined`. 
The example of README is wrong, it need to use `new URL()` to set `images.loc`.