### PR TITLE
chore(sitemap): fix transport error

### DIFF
--- a/packages/next-sitemap/src/builders/__tests__/sitemap-builder/build-sitemap-xml.test.ts
+++ b/packages/next-sitemap/src/builders/__tests__/sitemap-builder/build-sitemap-xml.test.ts
@@ -30,7 +30,7 @@ describe('SitemapBuilder', () => {
     // Expect the generated sitemap to match snapshot.
     expect(content).toMatchInlineSnapshot(`
       "<?xml version="1.0" encoding="UTF-8"?>
-      <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+      <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="https://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="https://www.w3.org/1999/xhtml" xmlns:mobile="https://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="https://www.google.com/schemas/sitemap-image/1.1" xmlns:video="https://www.google.com/schemas/sitemap-video/1.1">
       <url><loc>https://example.com</loc></url>
       <url><loc>https://example.com</loc><lastmod>some-value</lastmod><xhtml:link rel="alternate" hreflang="en" href="https://example.com/en"/><xhtml:link rel="alternate" hreflang="fr" href="https://example.com/fr"/></url>
       </urlset>"
@@ -56,7 +56,7 @@ describe('SitemapBuilder', () => {
     // Expect the generated sitemap to match snapshot.
     expect(content).toMatchInlineSnapshot(`
       "<?xml version="1.0" encoding="UTF-8"?>
-      <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+      <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="https://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="https://www.w3.org/1999/xhtml" xmlns:mobile="https://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="https://www.google.com/schemas/sitemap-image/1.1" xmlns:video="https://www.google.com/schemas/sitemap-video/1.1">
       <url><loc>https://example.com</loc><news:news><news:publication><news:name>The Example Times</news:name><news:language>en</news:language></news:publication><news:publication_date>2008-01-01T23:00:00.000+00:00</news:publication_date><news:title>Companies A&#44; B in Merger Talks</news:title></news:news></url>
       </urlset>"
     `)
@@ -87,7 +87,7 @@ describe('SitemapBuilder', () => {
     // Expect the generated sitemap to match snapshot.
     expect(content).toMatchInlineSnapshot(`
       "<?xml version="1.0" encoding="UTF-8"?>
-      <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+      <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="https://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="https://www.w3.org/1999/xhtml" xmlns:mobile="https://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="https://www.google.com/schemas/sitemap-image/1.1" xmlns:video="https://www.google.com/schemas/sitemap-video/1.1">
       <url><loc>https://example.com</loc><image:image><image:loc>https://example.com/</image:loc></image:image><image:image><image:loc>https://example.com/</image:loc><image:caption>Image caption &#38; description</image:caption><image:title>Image title</image:title><image:geo_location>Prague&#44; Czech Republic</image:geo_location><image:license>https://example.com/</image:license></image:image></url>
       </urlset>"
     `)
@@ -143,7 +143,7 @@ describe('SitemapBuilder', () => {
     // Expect the generated sitemap to match snapshot.
     expect(content).toMatchInlineSnapshot(`
       "<?xml version="1.0" encoding="UTF-8"?>
-      <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+      <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="https://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="https://www.w3.org/1999/xhtml" xmlns:mobile="https://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="https://www.google.com/schemas/sitemap-image/1.1" xmlns:video="https://www.google.com/schemas/sitemap-video/1.1">
       <url><loc>https://example.com</loc><video:video><video:title>Video title</video:title><video:thumbnail_loc>https://example.com/</video:thumbnail_loc><video:description>Video description</video:description><video:content_loc>https://example.com/</video:content_loc></video:video><video:video><video:title>Grilling steaks for summer</video:title><video:thumbnail_loc>https://example.com/</video:thumbnail_loc><video:description>Alkis shows you how to get perfectly done steaks every time</video:description><video:content_loc>https://example.com/</video:content_loc><video:player_loc>https://example.com/</video:player_loc><video:duration>600</video:duration><video:view_count>1234</video:view_count><video:tag>video</video:tag><video:rating>1.0</video:rating><video:expiration_date>2030-03-01T23:00:00.000+00:00</video:expiration_date><video:publication_date>2020-04-19T22:00:00.000+00:00</video:publication_date><video:family_friendly>yes</video:family_friendly><video:requires_subscription>no</video:requires_subscription><video:live>no</video:live><video:restriction relationship="deny">CZ</video:restriction><video:platform relationship="allow">web</video:platform><video:uploader info="https://example.com/">John Doe</video:uploader></video:video></url>
       </urlset>"
     `)

--- a/packages/next-sitemap/src/builders/sitemap-builder.ts
+++ b/packages/next-sitemap/src/builders/sitemap-builder.ts
@@ -17,7 +17,7 @@ export class SitemapBuilder {
    * @returns
    */
   withXMLTemplate(content: string): string {
-    return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">\n${content}</urlset>`
+    return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="https://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="https://www.w3.org/1999/xhtml" xmlns:mobile="https://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="https://www.google.com/schemas/sitemap-image/1.1" xmlns:video="https://www.google.com/schemas/sitemap-video/1.1">\n${content}</urlset>`
   }
 
   /**
@@ -28,7 +28,7 @@ export class SitemapBuilder {
   buildSitemapIndexXml(allSitemaps: string[]) {
     return [
       '<?xml version="1.0" encoding="UTF-8"?>',
-      '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+      '<sitemapindex xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">',
       ...(allSitemaps?.map((x) => `<sitemap><loc>${x}</loc></sitemap>`) ?? []),
       '</sitemapindex>',
     ].join('\n')


### PR DESCRIPTION
* Fix sitemap builder transport types

--

http transports will return as an error in the browser and with other sitemap tools like "Google Search Console".