### PR TITLE
Do not replace index if inside larger URL slug

### DIFF
--- a/packages/next-sitemap/src/parsers/manifest-parser.ts
+++ b/packages/next-sitemap/src/parsers/manifest-parser.ts
@@ -37,7 +37,7 @@ export class ManifestParser {
     return htmlFiles?.map((file) =>
       file
         .replace(exportFolder, '')
-        .replace('index', '')
+        .replace(/(^|\/)index($|\.)/, '$1$2')
         .replace('.html', '')
         .trim()
     )


### PR DESCRIPTION
I had an issue in my website's sitemap.

I have a blog post whose title / URL contains the word "index".

Realized `manifest-parser.ts` was indiscriminately replacing every instance of `index` by `''`.
I understand how beneficial it is to remove `$/index.html` from URLs but some people might want to keep the word "index" in their URL...

This new regex instead only replace `index` by `''` if:
- nothing is before "index" OR "/" is the character before index
AND
- nothing is after "index" OR "." is the character after index

After this change, my URL containing "index" doesn't get replaced by `''` anymore 😃 