### PR TITLE
Fix sitemap generation if next/headers is used

### DIFF
--- a/packages/next-sitemap/src/builders/url-set-builder.ts
+++ b/packages/next-sitemap/src/builders/url-set-builder.ts
@@ -74,6 +74,7 @@ export class UrlSetBuilder {
         ? Object.keys(this.manifest?.preRender?.routes ?? {})
         : []),
       ...(this.manifest?.staticExportPages ?? []),
+      ...(this.manifest?.trace?.filter(e => !!e.tags.path).map(e => e.tags.path!) ?? []),
     ]
 
     // Filter out next.js internal urls and generate urls based on sitemap

--- a/packages/next-sitemap/src/interface.ts
+++ b/packages/next-sitemap/src/interface.ts
@@ -208,6 +208,11 @@ export interface INextManifest {
   preRender?: IPreRenderManifest
   routes?: IRoutesManifest
   staticExportPages?: string[]
+  trace?: INextTrace[]
+}
+
+export interface INextTrace {
+  tags: { path?: string }
 }
 
 /**
@@ -236,6 +241,7 @@ export interface IRuntimePaths {
   SITEMAP_INDEX_FILE?: string
   SITEMAP_INDEX_URL?: string
   STATIC_EXPORT_ROOT: string
+  TRACE: string
 }
 
 export type IAlternateRef = {

--- a/packages/next-sitemap/src/parsers/manifest-parser.ts
+++ b/packages/next-sitemap/src/parsers/manifest-parser.ts
@@ -6,6 +6,7 @@ import type {
   IRuntimePaths,
   IRoutesManifest,
   IConfig,
+  INextTrace,
 } from '../interface.js'
 import { Logger } from '../logger.js'
 import { loadJSON } from '../utils/file.js'
@@ -70,11 +71,15 @@ export class ManifestParser {
       this.runtimePaths.STATIC_EXPORT_ROOT,
     )
 
+    // Load trace
+    const trace = await loadJSON<INextTrace[]>(this.runtimePaths.TRACE, true)
+
     return {
       build: buildManifest ?? ({} as any),
       preRender: preRenderManifest,
       routes: routesManifest,
       staticExportPages,
+      trace,
     }
   }
 }

--- a/packages/next-sitemap/src/utils/file.ts
+++ b/packages/next-sitemap/src/utils/file.ts
@@ -7,7 +7,10 @@ import path from 'node:path'
  * @param throwError
  * @returns
  */
-export const loadJSON = async <T>(path: string): Promise<T | undefined> => {
+export const loadJSON = async <T>(
+  path: string,
+  lineDelimited: boolean = false,
+): Promise<T | undefined> => {
   // Get path stat
   const stat = await fs.stat(path).catch(() => {
     return {
@@ -21,6 +24,18 @@ export const loadJSON = async <T>(path: string): Promise<T | undefined> => {
   }
 
   const jsonString = await fs.readFile(path, { encoding: 'utf-8' })
+
+  if (lineDelimited) {
+    const jsonLines = jsonString.split('\n')
+    return jsonLines
+      .map((line) => {
+        if (line.trim().length === 0) {
+          return []
+        }
+        return JSON.parse(line)
+      })
+      .reduce((accumulator, value) => accumulator.concat(value), [])
+  }
 
   return JSON.parse(jsonString)
 }

--- a/packages/next-sitemap/src/utils/path.ts
+++ b/packages/next-sitemap/src/utils/path.ts
@@ -45,6 +45,7 @@ export const getRuntimePaths = (config: IConfig): IRuntimePaths => {
     STATIC_EXPORT_ROOT: getPath(config.outDir!),
     SITEMAP_INDEX_URL,
     SITEMAP_INDEX_FILE,
+    TRACE: getPath(config.sourceDir!, 'trace'),
   }
 }
 


### PR DESCRIPTION
I was looking into issue #692 that I've also seen, if a page uses `next/headers` then the generated sitemap files are empty.

Admittedly I don't understand the NextJS internal files that are created, but I did find that:
1. When `headers()` is *not* included (normal behavior): page routes seem to show up in the `.next/prerender-manifest.json` file
2. When `headers()` is included: `prerender-manifest.json` is mostly empty, but there is another file `.next/trace` that seems to include the missing paths. `trace` is a line-delimited JSON file, each line contains an array of objects with an optional field `tags.path` containing the missing paths

This PR adds parsing of the `trace` file and addition to the manifest. It then uses this as input when building the URL set. I tested against the repro mentioned in #692 (https://github.com/bastienrobert/next-sitemap-generation-with-headers-repro) and it appears to fix the problem.

The parsing of the `trace` file could probably use some work (scanning each line instead of splitting on `\n`), but I wanted to get this PR up to get some feedback to make sure I'm on the right track.