### PR TITLE
Include dynamically rendered pages in sitemap

### DIFF
--- a/packages/next-sitemap/src/builders/url-set-builder.ts
+++ b/packages/next-sitemap/src/builders/url-set-builder.ts
@@ -74,6 +74,8 @@ export class UrlSetBuilder {
         ? Object.keys(this.manifest?.preRender?.routes ?? {})
         : []),
       ...(this.manifest?.staticExportPages ?? []),
+      ...(this.manifest?.routes?.staticRoutes?.map((route) => route?.page) ??
+        []),
     ]
 
     // Filter out next.js internal urls and generate urls based on sitemap

--- a/packages/next-sitemap/src/interface.ts
+++ b/packages/next-sitemap/src/interface.ts
@@ -197,6 +197,7 @@ export interface IRoutesManifest {
     locales: string[]
     defaultLocale: string
   }
+  staticRoutes?: { page: string }[]
 }
 
 export interface IExportMarker {


### PR DESCRIPTION
Add `manifest.routes.staticRoutes` to `allKeys` in `createUrlSet`.

Just taking a very naive stab at this, not sure this is even the right part of the manifest to pull these dynamically rendered paths from but I found my missing pages inside of it. `staticRoutes` seems like a weird name for the dynamic pages but that's where I found them. This seems to pick up some of the pages that went missing as soon as I called `headers()` or `cookies()`  from `import { headers, cookies } from 'next/headers';` in my page or layout. I've been running this patch in production since May.

Opting into dynamic rendering seems to put the page in a different place in the build output manifest:
> `headers()` is a [Dynamic Function](https://nextjs.org/docs/app/building-your-application/rendering/server-components#server-rendering-strategies#dynamic-functions) whose returned values cannot be known ahead of time. Using it in a layout or page will opt a route into [dynamic rendering](https://nextjs.org/docs/app/building-your-application/rendering/server-components#dynamic-rendering) at request time.

https://nextjs.org/docs/app/api-reference/functions/headers

Does this approach seem like a good direction? Any feedback? Just trying to start a conversation and hopefully solve https://github.com/iamvishnusankar/next-sitemap/issues/692 and https://github.com/iamvishnusankar/next-sitemap/issues/743.

Looks like there was an earlier attempt at https://github.com/iamvishnusankar/next-sitemap/pull/759.

I'm testing with Next v14.2.3 and patched next-sitemap v4.2.3 locally to test.