### PR TITLE
docs: update postbuild usage with pnpm from version 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You can also use a custom config file instead of `next-sitemap.config.js`. Just 
 
 #### Building sitemaps with pnpm
 
-When using pnpm you need to create a `.npmrc` file in the root of your project if you want to use a postbuild step:
+When using pnpm<9 you need to create a `.npmrc` file in the root of your project if you want to use a postbuild step:
 
 ```
 //.npmrc


### PR DESCRIPTION
In `pnpm>=9` `enable-pre-post-scripts` is true by default.
https://github.com/pnpm/pnpm/pull/7634