### PR TITLE
Bump fast-glob from 3.3.1 to 3.3.2

### DIFF
--- a/packages/next-sitemap/package.json
+++ b/packages/next-sitemap/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@corex/deepmerge": "^4.0.43",
     "@next/env": "^13.5.6",
-    "fast-glob": "^3.3.1",
+    "fast-glob": "^3.3.2",
     "minimist": "^1.2.8"
   },
   "peerDependencies": {


### PR DESCRIPTION
NPM is currently throwing an audit issue at users of next-sitemap 4.2.3. This is because is has dependencies on fast-glob version 3.1.1, which in turn has dependencies on micromatch 4.0.5, which finally has dependencies on braces 3.0.2.

There is a CVE associated with braces 3.0.2: https://github.com/advisories/GHSA-grv7-fg5c-xmjg

This patches the version.
